### PR TITLE
Drop pcre-light dependency by implementing formatMany's parser by hand

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -42,7 +42,6 @@ Library
     bytestring >= 0.9,
     containers,
     postgresql-libpq >= 0.6.2,
-    pcre-light,
     old-locale,
     template-haskell,
     text >= 0.11.1,
@@ -72,6 +71,7 @@ test-suite test
   other-modules:
     Common
     Bytea
+    ExecuteMany
     Notify
 
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-unused-do-bind

--- a/test/ExecuteMany.hs
+++ b/test/ExecuteMany.hs
@@ -1,0 +1,23 @@
+module ExecuteMany (testExecuteMany) where
+
+import Common
+
+import Data.ByteString (ByteString)
+
+testExecuteMany :: TestEnv -> Test
+testExecuteMany TestEnv{..} = TestCase $ do
+    execute_ conn "CREATE TEMPORARY TABLE tmp_executeMany (i INT, t TEXT, b BYTEA)"
+
+    let rows :: [(Int, String, Binary ByteString)]
+        rows = [ (1, "hello", Binary "bye")
+               , (2, "world", Binary "\0\r\t\n")
+               , (3, "?",     Binary "")
+               ]
+
+    count <- executeMany conn "INSERT INTO tmp_executeMany VALUES (?, ?, ?)" rows
+    assertEqual "count" (fromIntegral $ length rows) count
+
+    rows' <- query_ conn "SELECT * FROM tmp_executeMany"
+    assertEqual "rows" rows rows'
+
+    return ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,12 +5,14 @@ import System.Exit                  (exitFailure)
 import System.IO
 
 import Bytea
+import ExecuteMany
 import Notify
 
 tests :: [TestEnv -> Test]
 tests =
-    [ TestLabel "Bytea"     . testBytea
-    , TestLabel "Notify"    . testNotify
+    [ TestLabel "Bytea"         . testBytea
+    , TestLabel "Notify"        . testNotify
+    , TestLabel "ExecuteMany"   . testExecuteMany
     ]
 
 -- | Action for connecting to the database that will be used for testing.


### PR DESCRIPTION
I tried installing the pcre C library on Windows, but couldn't get it to work.  To spare myself and others of the major hassle of installing pcre on Windows, I implemented formatMany's parser by hand.

It's not an exact translation, though.  For example, the character allowed to appear before "VALUES" is not locale- and Unicode-dependent, but is based on PostgreSQL's lexical specification for identifiers.  I doubt any real-life query templates will be affected, though.

I also added a very trivial test case for executeMany.  It doesn't cover any interesting edge cases for parsing, but I have done a little testing of the parseTemplate function in GHCi.
