### PR TITLE
Added ToRow instance for (:.)

### DIFF
--- a/src/Database/PostgreSQL/Simple/ToRow.hs
+++ b/src/Database/PostgreSQL/Simple/ToRow.hs
@@ -22,7 +22,7 @@ module Database.PostgreSQL.Simple.ToRow
     ) where
 
 import Database.PostgreSQL.Simple.ToField (Action(..), ToField(..))
-import Database.PostgreSQL.Simple.Types (Only(..))
+import Database.PostgreSQL.Simple.Types (Only(..), (:.)(..))
 
 -- | A collection type that can be turned into a list of rendering
 -- 'Action's.
@@ -88,3 +88,6 @@ instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f,
 
 instance (ToField a) => ToRow [a] where
     toRow = map toField
+
+instance (ToRow a, ToRow b) => ToRow (a :. b) where
+    toRow (a :. b) = toRow a ++ toRow b


### PR DESCRIPTION
Very useful if you store multipart data in same table

``` haskell
updateSomethind id data_a_b data_c =
  execute conn "update \"foo_table\" set a = ?, b = ?, c = ? where id = ?"
      data_a_b :. data_c :. Only(id)
```
