### PR TITLE
Add SQL Field name to ResultError

### DIFF
--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -568,11 +568,11 @@ finishQuery conn q result = do
                                          , fmap ellipsis v       )
                               throw (ConversionFailed
                                (show (unCol ncols) ++ " values: " ++ show vals)
-                               Nothing
+                               ""
                                (show (unCol col) ++ " slots in target type")
                                "mismatch between number of columns to \
                                \convert and number in target type")
-             Errors []  -> throwIO $ ConversionFailed "" Nothing "" "unknown error"
+             Errors []  -> throwIO $ ConversionFailed "" "" "" "unknown error"
              Errors [x] -> throwIO x
              Errors xs  -> throwIO $ ManyErrors xs
     PQ.CopyOut ->

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -74,18 +74,18 @@ import qualified Data.Text.Lazy as LT
 -- | Exception thrown if conversion from a SQL value to a Haskell
 -- value fails.
 data ResultError = Incompatible { errSQLType :: String
-                                , errSQLField :: Maybe String
+                                , errSQLField :: String
                                 , errHaskellType :: String
                                 , errMessage :: String }
                  -- ^ The SQL and Haskell types are not compatible.
                  | UnexpectedNull { errSQLType :: String
-                                  , errSQLField :: Maybe String
+                                  , errSQLField :: String
                                   , errHaskellType :: String
                                   , errMessage :: String }
                  -- ^ A SQL @NULL@ was encountered when the Haskell
                  -- type did not permit it.
                  | ConversionFailed { errSQLType :: String
-                                    , errSQLField :: Maybe String
+                                    , errSQLField :: String
                                     , errHaskellType :: String
                                     , errMessage :: String }
                  -- ^ The SQL value could not be parsed, or could not
@@ -231,12 +231,12 @@ ff :: BuiltinType -> String -> (B8.ByteString -> Either String a)
    -> Field -> Maybe B8.ByteString -> Ok a
 ff pgType hsType parse f mstr
     | typeOid f /= builtin2oid pgType
-    = left (Incompatible   (B8.unpack (typename f)) (fmap B8.unpack (name f)) hsType "")
+    = left (Incompatible   (B8.unpack (typename f)) (maybe "" B8.unpack (name f)) hsType "")
     | Nothing <- mstr
-    = left (UnexpectedNull (B8.unpack (typename f)) (fmap B8.unpack (name f)) hsType "")
+    = left (UnexpectedNull (B8.unpack (typename f)) (maybe "" B8.unpack (name f)) hsType "")
     | Just str <- mstr
     = case parse str of
-        Left msg -> left (ConversionFailed (B8.unpack (typename f)) (fmap B8.unpack (name f)) hsType msg)
+        Left msg -> left (ConversionFailed (B8.unpack (typename f)) (maybe "" B8.unpack (name f)) hsType msg)
         Right val -> return val
 {-# INLINE ff #-}
 
@@ -284,10 +284,10 @@ doFromField f _ _ _ = returnError UnexpectedNull f ""
 --   exception value and returns it in a 'Left . SomeException'
 --   constructor.
 returnError :: forall a err . (Typeable a, Exception err)
-            => (String -> Maybe String -> String -> String -> err)
+            => (String -> String -> String -> String -> err)
             -> Field -> String -> Ok a
 returnError mkErr f = left . mkErr (B.unpack (typename f))
-                                   (fmap B.unpack (name f))
+                                   (maybe "" B.unpack (name f))
                                    (show (typeOf (undefined :: a)))
 
 atto :: forall a. (Typeable a)

--- a/src/Database/PostgreSQL/Simple/FromRow.hs
+++ b/src/Database/PostgreSQL/Simple/FromRow.hs
@@ -79,7 +79,7 @@ fieldWith fieldP = RP $ do
                        [0..ncols-1]
             convertError = ConversionFailed
                 (show (unCol ncols) ++ " values: " ++ show vals)
-                Nothing
+                ""
                 ("at least " ++ show (unCol column + 1)
                   ++ " slots in target type")
                 "mismatch between number of columns to \


### PR DESCRIPTION
This adds the sql field name to fromField's error messages. This is useful information when debugging unexpected parse errors.

Please let me know if you need me make any changes.
