### PR TITLE
Fix build for bytestring 0.10 (fixity issue with B.snoc)

### DIFF
--- a/src/Database/PostgreSQL/Simple/Arrays.hs
+++ b/src/Database/PostgreSQL/Simple/Arrays.hs
@@ -66,7 +66,7 @@ fmt = fmt' False
 delimit :: Char -> [ArrayFormat] -> ByteString
 delimit _      [] = ""
 delimit c     [x] = fmt' True c x
-delimit c (x:y:z) = fmt' True c x `B.snoc` c' `mappend` delimit c (y:z)
+delimit c (x:y:z) = (fmt' True c x `B.snoc` c') `mappend` delimit c (y:z)
   where
     c' | Array _ <- x = ','
        | otherwise    = c
@@ -77,9 +77,9 @@ delimit c (x:y:z) = fmt' True c x `B.snoc` c' `mappend` delimit c (y:z)
 fmt' :: Bool -> Char -> ArrayFormat -> ByteString
 fmt' quoting c x =
   case x of
-    Array items          -> '{' `B.cons` delimit c items `B.snoc` '}'
+    Array items          -> '{' `B.cons` (delimit c items `B.snoc` '}')
     Plain bytes          -> B.copy bytes
-    Quoted q | quoting   -> '"' `B.cons` esc q `B.snoc` '"'
+    Quoted q | quoting   -> '"' `B.cons` (esc q `B.snoc` '"')
              | otherwise -> B.copy q
     -- NB: The 'snoc' and 'cons' functions always copy.
 


### PR DESCRIPTION
This fixes the build for bytestring-0.10.2.0.  `B.snoc` is `infixl 5` now, meaning we can't do this without parentheses:

``` haskell
'{' `B.cons` delimit c items `B.snoc` '}'
```
