### PR TITLE
Define PGArray newtype instead of using Vector to represent Postgres arrays

### DIFF
--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -64,6 +64,7 @@ module Database.PostgreSQL.Simple
     , FromRow
     , In(..)
     , Binary(..)
+    , PGArray(..)
     , Only(..)
     , (:.)(..)
     -- ** Exceptions
@@ -143,7 +144,7 @@ import           Database.PostgreSQL.Simple.Ok
 import           Database.PostgreSQL.Simple.ToField (Action(..), inQuotes)
 import           Database.PostgreSQL.Simple.ToRow (ToRow(..))
 import           Database.PostgreSQL.Simple.Types
-                   ( Binary(..), In(..), Only(..), Query(..), (:.)(..) )
+                   ( Binary(..), PGArray(..), In(..), Only(..), Query(..), (:.)(..) )
 import           Database.PostgreSQL.Simple.Internal as Base
 import           Database.PostgreSQL.Simple.SqlQQ (sql)
 import qualified Database.PostgreSQL.LibPQ as PQ

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -58,13 +58,11 @@ import           Data.Maybe (fromMaybe)
 import           Data.Ratio (Ratio)
 import           Data.Time ( UTCTime, ZonedTime, LocalTime, Day, TimeOfDay )
 import           Data.Typeable (Typeable, typeOf)
-import           Data.Vector (Vector)
-import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Database.PostgreSQL.Simple.Internal
 import           Database.PostgreSQL.Simple.BuiltinTypes
 import           Database.PostgreSQL.Simple.Ok
-import           Database.PostgreSQL.Simple.Types (Binary(..), Null(..))
+import           Database.PostgreSQL.Simple.Types (Binary(..), PGArray(..), Null(..))
 import           Database.PostgreSQL.Simple.Time
 import           Database.PostgreSQL.Simple.Arrays
 import qualified Database.PostgreSQL.LibPQ as PQ
@@ -305,9 +303,9 @@ instance (FromField a, FromField b) => FromField (Either a b) where
     fromField f dat =   (Right <$> fromField f dat)
                     <|> (Left  <$> fromField f dat)
 
-instance (FromField a, Typeable a) => FromField (Vector a) where
+instance (FromField a, Typeable a) => FromField (PGArray a) where
     fromField f dat = either (returnError ConversionFailed f)
-                             (V.fromList <$>)
+                             (PGArray <$>)
                              (parseOnly (fromArray ',' f) (maybe "" id dat))
 
 fromArray :: (FromField a) => Char -> Field -> Parser (Ok [a])

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -32,15 +32,13 @@ import Data.Monoid (mappend)
 import Data.Time (Day, TimeOfDay, LocalTime, UTCTime, ZonedTime)
 import Data.Typeable (Typeable)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
-import Database.PostgreSQL.Simple.Types (Binary(..), In(..), Null)
+import Database.PostgreSQL.Simple.Types (Binary(..), PGArray(..), In(..), Null)
 import qualified Blaze.ByteString.Builder.Char.Utf8 as Utf8
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as ST
 import qualified Data.Text.Encoding as ST
 import qualified Data.Text.Lazy as LT
-import           Data.Vector (Vector)
-import qualified Data.Vector as V
 import qualified Database.PostgreSQL.LibPQ as PQ
 import           Database.PostgreSQL.Simple.Time
 
@@ -223,10 +221,10 @@ instance ToField Date where
     toField = Plain . inQuotes . dateToBuilder
     {-# INLINE toField #-}
 
-instance (ToField a) => ToField (Vector a) where
-    toField xs = Many $
+instance (ToField a) => ToField (PGArray a) where
+    toField (PGArray xs) = Many $
         Plain (fromByteString "ARRAY[") :
-        (intersperse (Plain (fromChar ',')) . map toField $ V.toList xs) ++
+        (intersperse (Plain (fromChar ',')) . map toField $ xs) ++
         [Plain (fromChar ']')]
         -- Because the ARRAY[...] input syntax is being used, it is possible
         -- that the use of type-specific separator characters is unnecessary.

--- a/src/Database/PostgreSQL/Simple/Types.hs
+++ b/src/Database/PostgreSQL/Simple/Types.hs
@@ -20,6 +20,7 @@ module Database.PostgreSQL.Simple.Types
     , Only(..)
     , In(..)
     , Binary(..)
+    , PGArray(..)
     , Query(..)
     , Oid(..)
     , (:.)(..)
@@ -110,6 +111,11 @@ newtype In a = In a
 -- | Wrap binary data for use as a @bytea@ value.
 newtype Binary a = Binary a
     deriving (Eq, Ord, Read, Show, Typeable, Functor)
+
+-- | Wrap a list for use as a PostgreSQL array.
+newtype PGArray a = PGArray {
+      fromPGArray :: [a]
+    } deriving (Eq, Ord, Read, Show, Typeable, Functor)
 
 -- | A composite type to parse your custom data structures without
 -- having to define dummy newtype wrappers every time.


### PR DESCRIPTION
Using `Vector`, it's awkward (and perhaps less efficient) if you want to use a regular Haskell list in a record:

``` haskell
import qualified Data.Vector as V

data Widget = Widget
    { foo     :: String
    , bar     :: String
    , baz     :: String
    , reports :: [String]
    }

instance FromRow Widget where
    fromRow = do
        foo     <- field
        bar     <- field
        baz     <- field
        reports <- V.toList <$> field -- Postgres array
        return Widget{..}
```

Moreover, it's not safe.  Suppose in the future, postgresql-simple serializes Vector and Map using JSON so they stack properly (PostgreSQL arrays can't be nested; they're multi-dimensional, like matrices).  Code that relies on Vector being a Postgres array will break at run-time.

We discussed this before in pull request #33, but it bothered me when I had to write code like the above.

@lpsmith, @solidsnack, and @sopvop, are you okay with this?  My commit will break existing code using PG array support, but it will produce a compile-time error that is easy to fix (no `ToField` and `FromField` instances for `Vector`), rather than subtle breakage at runtime.
