### PR TITLE
Fix: allow empty hstore's and enforce complete parse.

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,2 @@
+:set -isrc
+:set Wall

--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -1,5 +1,5 @@
 Name:                postgresql-simple
-Version:             0.3.1.0
+Version:             0.3.1.1
 Synopsis:            Mid-Level PostgreSQL client library
 Description:
     Mid-Level PostgreSQL client library, forked from mysql-simple.


### PR DESCRIPTION
Hi Leon,

thanks for building HStore support into `postgresql-simple`. This patch fixes the problem that your parser barked on empty hstores.

best regards,
Simon

PS: It would be great, if you could release a bugfix quite soon.
