### PR TITLE
Do not reverse key-value pairs in hstore parser.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Version 0.3.1.2 (2013-04-29)
+  * Fixed hstore parser to not unnecessarily reverse the key-value pairs
+
 Version 0.3.1.1 (2013-04-29)
   * Fixed hstore parser to recognize empty hstores
 

--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -1,5 +1,5 @@
 Name:                postgresql-simple
-Version:             0.3.1.1
+Version:             0.3.1.2
 Synopsis:            Mid-Level PostgreSQL client library
 Description:
     Mid-Level PostgreSQL client library, forked from mysql-simple.

--- a/src/Database/PostgreSQL/Simple/HStore/Implementation.hs
+++ b/src/Database/PostgreSQL/Simple/HStore/Implementation.hs
@@ -152,13 +152,10 @@ instance FromField HStoreMap where
       where convert (HStoreList xs) = HStoreMap (Map.fromList xs)
 
 parseHStore :: P.Parser (Either UnicodeException HStoreList)
-parseHStore =
-    reverseEither [] <$> P.sepBy' (skipWhiteSpace *> parseHStoreKeyVal)
-                                  (skipWhiteSpace *> P.word8 (c2w ','))
-  where
-    reverseEither acc []                = Right (HStoreList acc)
-    reverseEither _acc ((Left err):_xs) = Left err
-    reverseEither acc ((Right x ):xs)   = reverseEither (x:acc) xs
+parseHStore = do
+    kvs <- P.sepBy' (skipWhiteSpace *> parseHStoreKeyVal)
+                    (skipWhiteSpace *> P.word8 (c2w ','))
+    return $ HStoreList <$> sequence kvs
 
 parseHStoreKeyVal :: P.Parser (Either UnicodeException (Text,Text))
 parseHStoreKeyVal = do


### PR DESCRIPTION
Sorry for introducing this unnecessary reversing behaviour.
