### PR TITLE
Parse a strict ByteString to a JSON.Value directly using eitherDecodeStrict'

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -52,7 +52,7 @@ Library
      Database.PostgreSQL.Simple.TypeInfo.Types
 
   Build-depends:
-    aeson >= 0.6,
+    aeson >= 0.6.2,
     attoparsec >= 0.10.3,
     base < 5,
     blaze-builder,

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -452,7 +452,7 @@ instance FromField JSON.Value where
       else case mbs of
              Nothing -> returnError UnexpectedNull f ""
              Just bs ->
-                 case JSON.eitherDecode' $ LB.fromChunks [bs] of
+                 case JSON.eitherDecodeStrict' bs of
                    Left  err -> returnError ConversionFailed f err
                    Right val -> pure val
 


### PR DESCRIPTION
I realized the latest aeson added decoders for strict ByteStrings. So there's no need to first convert to a lazy ByteString.

The only thing I'm not sure about is which of these to use:
- `eitherDecodeStrict`:
  The conversion of a parsed value to a Haskell value is deferred until the Haskell value is needed. This may improve performance if only a subset of the results of conversions are needed, but at a cost in thunk allocation.
- `eitherDecodeStrict'`:
  This is a strict version which avoids building up thunks during parsing; it performs all conversions immediately. Prefer this version if most of the JSON data needs to be accessed.

I've now chosen `eitherDecodeStrict'` since that gives more predicatable memmory usage. Also if the user doesn't need to parse the whole `JSON.Value` he could choose not to return the whole JSON string from the query (using the postgresql-9.3 [JSON functions](http://www.postgresql.org/docs/9.3/static/functions-json.html)).
