### PR TITLE
Parse NULL values in arrays correctly.

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -444,9 +444,13 @@ fromArray typeInfo f = sequence . (parseIt <$>) <$> array delim
   where
     delim = typdelim (typelem typeInfo)
     fElem = f{ typeOid = typoid (typelem typeInfo) }
-    parseIt item = (fromField f' . Just . fmt delim) item
-      where f' | Arrays.Array _ <- item = f
-               | otherwise              = fElem
+
+    parseIt item =
+        fromField f' $ if item' == "NULL" then Nothing else Just item'
+      where
+        item' = fmt delim item
+        f' | Arrays.Array _ <- item = f
+           | otherwise              = fElem
 
 instance (FromField a, Typeable a) => FromField (Vector a) where
     fromField f v = V.fromList . fromPGArray <$> fromField f v


### PR DESCRIPTION
`NULL` values in arrays are not currently parsed correctly:

```
λ> ints :: [Pg.Only (V.Vector (Maybe Int))] <- Pg.query_ conn "SELECT '{1, NULL}' :: int[]"
*** Exception: ConversionFailed {errSQLType = "_int4", errSQLTableOid = Nothing, errSQLField = "int4", errHaskellType = "Int", errMessage = "Failed reading: takeWhile1"}
```

This is because each value of the array is assumed to be non-null.  The patch fixes this problem but it's more a proof-of-concept than anything else, since I don't really know much about the codebase and I don't know if that's the right way of doing things (maybe there are other ways NULL values can be represented etc.)
