### PR TITLE
added conversion between interval and DiffTime

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -115,7 +115,7 @@ import qualified Data.ByteString.Char8 as B
 import           Data.Int (Int16, Int32, Int64)
 import           Data.IORef (IORef, newIORef)
 import           Data.Ratio (Ratio)
-import           Data.Time ( UTCTime, ZonedTime, LocalTime, Day, TimeOfDay )
+import           Data.Time ( UTCTime, ZonedTime, LocalTime, Day, TimeOfDay, DiffTime )
 import           Data.Typeable (Typeable, typeOf)
 import           Data.Vector (Vector)
 import           Data.Vector.Mutable (IOVector)
@@ -415,6 +415,10 @@ instance FromField LocalTimestamp where
 -- | date
 instance FromField Date where
   fromField = ff $(inlineTypoid TI.date) "Date" parseDate
+
+-- | interval
+instance FromField DiffTime where
+  fromField = ff $(inlineTypoid TI.interval) "DiffTime" parseInterval
 
 ff :: PQ.Oid -> String -> (B8.ByteString -> Either String a)
    -> Field -> Maybe B8.ByteString -> Conversion a

--- a/src/Database/PostgreSQL/Simple/Time.hs
+++ b/src/Database/PostgreSQL/Simple/Time.hs
@@ -64,6 +64,7 @@ module Database.PostgreSQL.Simple.Time
      , parseUTCTimestamp
      , parseZonedTimestamp
      , parseLocalTimestamp
+     , parseInterval
      , dayToBuilder
      , utcTimeToBuilder
      , zonedTimeToBuilder
@@ -71,6 +72,7 @@ module Database.PostgreSQL.Simple.Time
      , timeOfDayToBuilder
      , timeZoneToBuilder
      , dateToBuilder
+     , diffTimeToBuilder
      , utcTimestampToBuilder
      , zonedTimestampToBuilder
      , localTimestampToBuilder

--- a/src/Database/PostgreSQL/Simple/Time/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Time/Internal.hs
@@ -19,6 +19,7 @@ module Database.PostgreSQL.Simple.Time.Internal
      , getZonedTimestamp
      , getUTCTime
      , getUTCTimestamp
+     , getInterval
      ) where
 
 import Database.PostgreSQL.Simple.Time.Implementation

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -30,7 +30,7 @@ import Data.ByteString (ByteString)
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
 import Data.Monoid (mappend)
-import Data.Time (Day, TimeOfDay, LocalTime, UTCTime, ZonedTime)
+import Data.Time (Day, TimeOfDay, LocalTime, UTCTime, ZonedTime, DiffTime)
 import Data.Typeable (Typeable)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import {-# SOURCE #-} Database.PostgreSQL.Simple.ToRow
@@ -259,6 +259,10 @@ instance ToField LocalTimestamp where
 
 instance ToField Date where
     toField = Plain . inQuotes . dateToBuilder
+    {-# INLINE toField #-}
+
+instance ToField DiffTime where
+    toField = Plain . inQuotes . diffTimeToBuilder
     {-# INLINE toField #-}
 
 instance (ToField a) => ToField (PGArray a) where


### PR DESCRIPTION
I needed to be able to access and store `interval` values in Postgres for a personal project, so I added conversion between `interval` and `Data.Time.DiffTime`. You might be interested in my code.
