### PR TITLE
Implement range type

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -31,6 +31,8 @@ Library
      Database.PostgreSQL.Simple.Notification
      Database.PostgreSQL.Simple.Ok
      Database.PostgreSQL.Simple.Range
+     Database.PostgreSQL.Simple.Range.Implementation
+     Database.PostgreSQL.Simple.Range.Simple
      Database.PostgreSQL.Simple.SqlQQ
      Database.PostgreSQL.Simple.Time
      Database.PostgreSQL.Simple.Time.Internal

--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -30,6 +30,7 @@ Library
      Database.PostgreSQL.Simple.HStore.Internal
      Database.PostgreSQL.Simple.Notification
      Database.PostgreSQL.Simple.Ok
+     Database.PostgreSQL.Simple.Range
      Database.PostgreSQL.Simple.SqlQQ
      Database.PostgreSQL.Simple.Time
      Database.PostgreSQL.Simple.Time.Internal

--- a/src/Database/PostgreSQL/Simple/Compat.hs
+++ b/src/Database/PostgreSQL/Simple/Compat.hs
@@ -6,6 +6,7 @@ module Database.PostgreSQL.Simple.Compat
     , (<>)
     , unsafeDupablePerformIO
     , toByteString
+    , scientificBuilder
     ) where
 
 import qualified Control.Exception as E
@@ -14,6 +15,12 @@ import Data.ByteString         (ByteString)
 import Data.ByteString.Lazy    (toStrict)
 import Data.ByteString.Builder (Builder, toLazyByteString)
 
+
+#if MIN_VERSION_scientific(0,3,0)
+import Data.Text.Lazy.Builder.Scientific (scientificBuilder)
+#else
+import Data.Scientific (scientificBuilder)
+#endif
 
 #if   __GLASGOW_HASKELL__ >= 702
 import System.IO.Unsafe (unsafeDupablePerformIO)

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -549,14 +549,12 @@ instance (FromField a, Typeable a) => FromField (PGRange a) where
           Just "empty" -> pure $ PGRange Unbounded Unbounded
           Just bs ->
             let parseIt Unbounded     = pure Unbounded
-                parseIt (Inclusive v) = Inclusive <$> fromField f' (nullNothing v)
-                parseIt (Exclusive v) = Exclusive <$> fromField f' (nullNothing v)
+                parseIt (Inclusive v) = Inclusive <$> fromField f' v
+                parseIt (Exclusive v) = Exclusive <$> fromField f' v
             in case parseOnly pgrange bs of
                 Left e -> returnError ConversionFailed f e
                 Right (lb,ub) -> PGRange <$> parseIt lb <*> parseIt ub
       _ -> returnError Incompatible f ""
-    where
-      nullNothing v = if B.null v then Nothing else Just v
 
 -- | json
 instance FromField JSON.Value where

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -112,7 +112,7 @@ module Database.PostgreSQL.Simple.FromField
 
 #include "MachDeps.h"
 
-import           Control.Applicative ( (<|>), (<$>), pure, (*>) )
+import           Control.Applicative ( (<|>), (<$>), pure, (*>), (<*>) )
 import           Control.Concurrent.MVar (MVar, newMVar)
 import           Control.Exception (Exception)
 import qualified Data.Aeson as JSON
@@ -131,6 +131,7 @@ import           Database.PostgreSQL.Simple.Internal
 import           Database.PostgreSQL.Simple.Compat
 import           Database.PostgreSQL.Simple.Ok
 import           Database.PostgreSQL.Simple.Types
+import           Database.PostgreSQL.Simple.Range
 import           Database.PostgreSQL.Simple.TypeInfo as TI
 import qualified Database.PostgreSQL.Simple.TypeInfo.Static as TI
 import           Database.PostgreSQL.Simple.TypeInfo.Macro as TI
@@ -536,6 +537,26 @@ instance FromField UUID where
                  case UUID.fromASCIIBytes bs of
                    Nothing -> returnError ConversionFailed f "Invalid UUID"
                    Just uuid -> pure uuid
+
+instance (FromField a, Typeable a) => FromField (PGRange a) where
+  fromField f mdat = do
+    info <- typeInfo f
+    case info of
+      Range{} ->
+        let f' = f { typeOid = typoid (rngsubtype info) }
+        in case mdat of
+          Nothing -> returnError UnexpectedNull f ""
+          Just "empty" -> pure $ PGRange Unbounded Unbounded
+          Just bs ->
+            let parseIt Unbounded     = pure Unbounded
+                parseIt (Inclusive v) = Inclusive <$> fromField f' (nullNothing v)
+                parseIt (Exclusive v) = Exclusive <$> fromField f' (nullNothing v)
+            in case parseOnly pgrange bs of
+                Left e -> returnError ConversionFailed f e
+                Right (lb,ub) -> PGRange <$> parseIt lb <*> parseIt ub
+      _ -> returnError Incompatible f ""
+    where
+      nullNothing v = if B.null v then Nothing else Just v
 
 -- | json
 instance FromField JSON.Value where

--- a/src/Database/PostgreSQL/Simple/Range.hs
+++ b/src/Database/PostgreSQL/Simple/Range.hs
@@ -1,84 +1,28 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
 module Database.PostgreSQL.Simple.Range
+       ( RangeBound(..)
+       , PGRange (..)
+       -- * Predicates
+       , isEmpty
+       , isInfiniteRange
+       , isLowerInfinite
+       , isUpperInfinite
+       , isLowerInclusive
+       , isUpperInclusive
+       , isSimpleRange
+       -- @ Functions on ranges
+       , lowerBound
+       , upperBound
+       , containsElem
+       , containsRange
+       , overlaps
+       , withinLeftBoundOf
+       , withinRightBoundOf
+       )
        where
 
-import           Blaze.ByteString.Builder (Builder, fromByteString, toByteString)
-import           Blaze.ByteString.Builder.Char8    (fromChar)
-import           Control.Applicative
-import           Data.Attoparsec.ByteString.Char8  (Parser)
-import qualified Data.Attoparsec.ByteString.Char8  as A
-import qualified Data.ByteString                   as B
-import           Data.Monoid                       (mempty)
-import           Data.Typeable                     (Typeable)
-
-import           Database.PostgreSQL.Simple.Compat ((<>))
-
--- | Represents boundary of a range
-data RangeBound a = Unbounded
-                  | Inclusive a
-                  | Exclusive a
-     deriving (Show, Typeable, Eq, Ord, Functor)
-
--- | Generic range type
-data PGRange a = PGRange (RangeBound a) (RangeBound a)
-     deriving (Show, Typeable, Eq, Ord, Functor)
-
-lowerBound :: Parser (a -> RangeBound a)
-lowerBound = (A.char '(' *> pure Exclusive) <|> (A.char '[' *> pure Inclusive)
-{-# INLINE lowerBound #-}
-
-upperBound :: Parser (a -> RangeBound a)
-upperBound = (A.char ')' *> pure Exclusive) <|> (A.char ']' *> pure Inclusive)
-{-# INLINE upperBound #-}
-
--- | Generic range parser
-pgrange :: Parser (RangeBound B.ByteString, RangeBound B.ByteString)
-pgrange = do
-  lb <- lowerBound
-  v1 <- (A.char ',' *> "") <|> (rangeElem (==',') <* A.char ',')
-  v2 <- rangeElem $ \c -> c == ')' || c == ']'
-  ub <- upperBound
-  A.endOfInput
-  let low = if B.null v1 then Unbounded else lb v1
-      up  = if B.null v2 then Unbounded else ub v2
-  return (low, up)
-
-rangeElem :: (Char -> Bool) -> Parser B.ByteString
-rangeElem end = (A.char '"' *> doubleQuoted)
-            <|> A.takeTill end
-{-# INLiNE rangeElem #-}
-
--- | Simple double quoted value parser
-doubleQuoted :: Parser B.ByteString
-doubleQuoted = toByteString <$> go mempty
-  where
-    go acc = do
-      h <- fromByteString <$> A.takeTill (\c -> c == '\\' || c == '"')
-      let rest = do
-           start <- A.anyChar
-           case start of
-             '\\' -> do
-               c <- A.anyChar
-               go (acc <> h <> fromChar c)
-             '"' -> (A.char '"' *> go (acc <> h <> fromChar '"'))
-                    <|> pure (acc <> h)
-             _ -> error "impossible in doubleQuoted"
-      rest
-
--- | Generic range to builder for plain values
-rangeToBuilder :: (a -> Builder) -> PGRange a -> Builder
-rangeToBuilder _ (PGRange Unbounded Unbounded) = fromByteString "'empty'"
-rangeToBuilder f (PGRange a b) = buildLB a <> buildUB b
-  where
-    buildLB Unbounded = fromByteString "'[,"
-    buildLB (Inclusive v) = fromByteString "'[\"" <> f v <> fromByteString "\","
-    buildLB (Exclusive v) = fromByteString "'(\"" <> f v <> fromByteString "\","
-
-    buildUB Unbounded = fromByteString "]'"
-    buildUB (Inclusive v) = fromChar '"' <> f v <> fromByteString "\"]'"
-    buildUB (Exclusive v) = fromChar '"' <> f v <> fromByteString "\")'"
-{-# INLINE rangeToBuilder #-}
-
+import           Database.PostgreSQL.Simple.Range.Implementation

--- a/src/Database/PostgreSQL/Simple/Range.hs
+++ b/src/Database/PostgreSQL/Simple/Range.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+
+module Database.PostgreSQL.Simple.Range
+       where
+
+import           Blaze.ByteString.Builder (Builder, fromByteString, toByteString)
+import           Blaze.ByteString.Builder.Char8    (fromChar)
+import           Control.Applicative
+import           Data.Attoparsec.ByteString.Char8  (Parser)
+import qualified Data.Attoparsec.ByteString.Char8  as A
+import qualified Data.ByteString                   as B
+import           Data.Monoid                       (mempty)
+import           Data.Typeable                     (Typeable)
+
+import           Database.PostgreSQL.Simple.Compat ((<>))
+
+-- | Represents boundary of a range
+data RangeBound a = Unbounded
+                  | Inclusive a
+                  | Exclusive a
+     deriving (Show, Typeable, Eq, Ord, Functor)
+
+-- | Generic range type
+data PGRange a = PGRange (RangeBound a) (RangeBound a)
+     deriving (Show, Typeable, Eq, Ord, Functor)
+
+lowerBound :: Parser (a -> RangeBound a)
+lowerBound = (A.char '(' *> pure Exclusive) <|> (A.char '[' *> pure Inclusive)
+{-# INLINE lowerBound #-}
+
+upperBound :: Parser (a -> RangeBound a)
+upperBound = (A.char ')' *> pure Exclusive) <|> (A.char ']' *> pure Inclusive)
+{-# INLINE upperBound #-}
+
+-- | Generic range parser
+pgrange :: Parser (RangeBound B.ByteString, RangeBound B.ByteString)
+pgrange = do
+  lb <- lowerBound
+  v1 <- (A.char ',' *> "") <|> (rangeElem (==',') <* A.char ',')
+  v2 <- rangeElem $ \c -> c == ')' || c == ']'
+  ub <- upperBound
+  A.endOfInput
+  let low = if B.null v1 then Unbounded else lb v1
+      up  = if B.null v2 then Unbounded else ub v2
+  return (low, up)
+
+rangeElem :: (Char -> Bool) -> Parser B.ByteString
+rangeElem end = (A.char '"' *> doubleQuoted)
+            <|> A.takeTill end
+{-# INLiNE rangeElem #-}
+
+-- | Simple double quoted value parser
+doubleQuoted :: Parser B.ByteString
+doubleQuoted = toByteString <$> go mempty
+  where
+    go acc = do
+      h <- fromByteString <$> A.takeTill (\c -> c == '\\' || c == '"')
+      let rest = do
+           start <- A.anyChar
+           case start of
+             '\\' -> do
+               c <- A.anyChar
+               go (acc <> h <> fromChar c)
+             '"' -> (A.char '"' *> go (acc <> h <> fromChar '"'))
+                    <|> pure (acc <> h)
+             _ -> error "impossible in doubleQuoted"
+      rest
+
+-- | Generic range to builder for plain values
+rangeToBuilder :: (a -> Builder) -> PGRange a -> Builder
+rangeToBuilder _ (PGRange Unbounded Unbounded) = fromByteString "'empty'"
+rangeToBuilder f (PGRange a b) = buildLB a <> buildUB b
+  where
+    buildLB Unbounded = fromByteString "'[,"
+    buildLB (Inclusive v) = fromByteString "'[\"" <> f v <> fromByteString "\","
+    buildLB (Exclusive v) = fromByteString "'(\"" <> f v <> fromByteString "\","
+
+    buildUB Unbounded = fromByteString "]'"
+    buildUB (Inclusive v) = fromChar '"' <> f v <> fromByteString "\"]'"
+    buildUB (Exclusive v) = fromChar '"' <> f v <> fromByteString "\")'"
+{-# INLINE rangeToBuilder #-}
+

--- a/src/Database/PostgreSQL/Simple/Range/Implementation.hs
+++ b/src/Database/PostgreSQL/Simple/Range/Implementation.hs
@@ -1,0 +1,378 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+
+module Database.PostgreSQL.Simple.Range.Implementation
+       where
+
+import           Blaze.ByteString.Builder             (Builder, fromByteString,
+                                                       fromLazyByteString,
+                                                       toByteString)
+import           Blaze.ByteString.Builder.Char8       (fromChar)
+import           Blaze.Text                           (double, float, integral)
+import           Control.Applicative
+import           Data.Attoparsec.ByteString.Char8     (Parser, parseOnly)
+import qualified Data.Attoparsec.ByteString.Char8     as A
+import qualified Data.ByteString                      as B
+import           Data.Int                             (Int16, Int32, Int64,
+                                                       Int8)
+import           Data.Maybe                           (fromMaybe, isNothing)
+import           Data.Monoid                          (mempty)
+import           Data.Scientific                      (Scientific)
+import qualified Data.Text.Lazy.Builder               as LT
+import qualified Data.Text.Lazy.Encoding              as LT
+import           Data.Time                            (Day, LocalTime,
+                                                       NominalDiffTime,
+                                                       TimeOfDay, UTCTime,
+                                                       ZonedTime)
+import           Data.Typeable                        (Typeable)
+import           Data.Word                            (Word, Word16, Word32,
+                                                       Word64, Word8)
+
+import           Database.PostgreSQL.Simple.Compat    (scientificBuilder, (<>))
+import           Database.PostgreSQL.Simple.FromField
+import           Database.PostgreSQL.Simple.Time
+import           Database.PostgreSQL.Simple.ToField
+
+
+-- | Represents boundary of a range
+data RangeBound a = Inclusive a
+                  | Exclusive a
+     deriving (Show, Typeable, Eq, Ord, Functor)
+
+-- | Generic range type
+data PGRange a = EmptyRange
+             | PGRange (Maybe (RangeBound a)) (Maybe (RangeBound a))
+     deriving (Show, Typeable, Eq, Ord, Functor)
+
+
+boundValue :: RangeBound t -> t
+boundValue (Inclusive a) = a
+boundValue (Exclusive a) = a
+
+-- | check if range be represented as simple range
+isSimpleRange :: PGRange t -> Bool
+isSimpleRange (PGRange Nothing Nothing) = True
+isSimpleRange (PGRange Nothing (Just (Exclusive _))) = True
+isSimpleRange (PGRange (Just (Inclusive _)) Nothing) = True
+isSimpleRange (PGRange (Just (Inclusive _)) (Just (Exclusive _))) = True
+isSimpleRange _ = False
+
+-- | Is range empty
+isEmpty :: Eq a => PGRange a -> Bool
+isEmpty EmptyRange = True
+isEmpty (PGRange (Just (Inclusive _)) (Just (Inclusive _))) = False -- at least one elem
+isEmpty (PGRange (Just l) (Just r)) = boundValue l == boundValue r
+isEmpty _          = False
+
+-- | Is range unbounded on both ends
+isInfiniteRange :: PGRange t -> Bool
+isInfiniteRange (PGRange Nothing Nothing) = True
+isInfiniteRange _ = False
+
+-- | @lower_inf@ in postgres
+isLowerInfinite :: PGRange t -> Bool
+isLowerInfinite (PGRange Nothing _) = True
+isLowerInfinite _ = False
+
+-- | @upper_inf@ in postgres
+isUpperInfinite :: PGRange t -> Bool
+isUpperInfinite (PGRange _ Nothing) = True
+isUpperInfinite _ = False
+
+-- | @lower_inc@ in postgres
+isLowerInclusive :: PGRange t -> Bool
+isLowerInclusive (PGRange (Just (Inclusive _)) _ ) = True
+isLowerInclusive _ = False
+
+-- | @upper_inc@ in postgres
+isUpperInclusive :: PGRange t -> Bool
+isUpperInclusive (PGRange _ (Just (Inclusive _))) = True
+isUpperInclusive _ = False
+
+-- | @lower@ in postgres
+lowerBound :: PGRange t -> Maybe (RangeBound t)
+lowerBound (PGRange l _ ) = l
+lowerBound _ = Nothing
+
+-- | @upper@ in postgres
+upperBound :: PGRange t -> Maybe (RangeBound t)
+upperBound (PGRange _ u ) = u
+upperBound _ = Nothing
+
+-- | Value is to the right of the boundary
+satisfiesLeftBound :: Ord a => a -> RangeBound a -> Bool
+satisfiesLeftBound v (Inclusive b) = v >= b
+satisfiesLeftBound v (Exclusive b) = v > b
+
+-- | Value is to the left of the boundary
+satisfiesRightBound :: Ord a => a -> RangeBound a -> Bool
+satisfiesRightBound v (Inclusive b) = v <= b
+satisfiesRightBound v (Exclusive b) = v < b
+
+-- | The first bound is not to the left of second bound
+overlapsLeftBound :: Ord a => RangeBound a -> RangeBound a -> Bool
+overlapsLeftBound (Inclusive v) (Inclusive b) = v >= b
+overlapsLeftBound v b = boundValue v > boundValue b
+
+-- | first boundary is further left from second boundary
+extendsToLeftOfBound :: Ord a => RangeBound a -> RangeBound a -> Bool
+extendsToLeftOfBound (Inclusive a) (Exclusive b) = a <= b
+extendsToLeftOfBound a b = boundValue a < boundValue b
+
+-- | first boundary is further right from second boundary
+extendsToRightOfBound :: Ord a => RangeBound a -> RangeBound a -> Bool
+extendsToRightOfBound (Inclusive a) (Exclusive b) = a >= b
+extendsToRightOfBound a b = boundValue a > boundValue b
+
+-- | The first bound is not to the right of second bound
+overlapsRightBound :: Ord a => RangeBound a -> RangeBound a -> Bool
+overlapsRightBound (Inclusive v) (Inclusive b) = v <= b
+overlapsRightBound v b = boundValue v < boundValue b
+
+-- | (@\@>@) for elements
+containsElem :: Ord a => PGRange a -> a -> Bool
+containsElem EmptyRange _ = False
+containsElem (PGRange Nothing Nothing) _= True
+containsElem (PGRange (Just l) Nothing) e = satisfiesLeftBound e l
+containsElem (PGRange Nothing (Just r)) e = satisfiesRightBound e r
+containsElem (PGRange (Just l) (Just r)) e =
+    satisfiesLeftBound e l && satisfiesRightBound e r
+
+-- | (@\@>@) for ranges
+containsRange :: Ord a => PGRange a -> PGRange a -> Bool
+containsRange a b = withinLeftBoundOf b a && withinRightBoundOf b a
+
+-- | @&<@ does not extend to the right of
+withinLeftBoundOf :: Ord a => PGRange a -> PGRange a -> Bool
+withinLeftBoundOf EmptyRange _ = False
+withinLeftBoundOf _ EmptyRange = False
+withinLeftBoundOf (PGRange Nothing  _) (PGRange b _) = isNothing b
+withinLeftBoundOf (PGRange (Just v) _) (PGRange b _) =
+   fromMaybe True $ not . extendsToLeftOfBound v <$> b
+
+-- | @&>@ does not extend to the left of
+withinRightBoundOf :: Ord a => PGRange a -> PGRange a -> Bool
+withinRightBoundOf EmptyRange _ = False
+withinRightBoundOf _ EmptyRange = False
+withinRightBoundOf (PGRange _  Nothing) (PGRange _ b) = isNothing b
+withinRightBoundOf (PGRange _ (Just v)) (PGRange _ b) =
+   fromMaybe True $ not . extendsToRightOfBound v <$> b
+
+-- | @&&@ - do ranges have common points
+overlaps :: Ord a => PGRange a -> PGRange a -> Bool
+overlaps EmptyRange _ = False
+overlaps _ EmptyRange = False
+overlaps (PGRange ll lr) (PGRange rl rr) = left && right
+    where
+      left = case ll of
+        Nothing -> True
+        Just v -> fromMaybe True $ overlapsRightBound v <$> rr
+      right = case lr of
+        Nothing -> True
+        Just v -> fromMaybe True $ overlapsLeftBound v <$> rl
+
+------ Parsing ------
+
+parseLowerBound :: Parser (a -> RangeBound a)
+parseLowerBound = (A.char '(' *> pure Exclusive) <|> (A.char '[' *> pure Inclusive)
+{-# INLINE parseLowerBound #-}
+
+parseUpperBound :: Parser (a -> RangeBound a)
+parseUpperBound = (A.char ')' *> pure Exclusive) <|> (A.char ']' *> pure Inclusive)
+{-# INLINE parseUpperBound #-}
+
+-- | Generic range parser
+pgrange :: Parser (Maybe (RangeBound B.ByteString), Maybe (RangeBound B.ByteString))
+pgrange = do
+  lb <- parseLowerBound
+  v1 <- (A.char ',' *> "") <|> (rangeElem (==',') <* A.char ',')
+  v2 <- rangeElem $ \c -> c == ')' || c == ']'
+  ub <- parseUpperBound
+  A.endOfInput
+  let low = if B.null v1 then Nothing else Just $ lb v1
+      up  = if B.null v2 then Nothing else Just $ ub v2
+  return (low, up)
+
+rangeElem :: (Char -> Bool) -> Parser B.ByteString
+rangeElem end = (A.char '"' *> doubleQuoted)
+            <|> A.takeTill end
+{-# INLiNE rangeElem #-}
+
+-- | Simple double quoted value parser
+doubleQuoted :: Parser B.ByteString
+doubleQuoted = toByteString <$> go mempty
+  where
+    go acc = do
+      h <- fromByteString <$> A.takeTill (\c -> c == '\\' || c == '"')
+      let rest = do
+           start <- A.anyChar
+           case start of
+             '\\' -> do
+               c <- A.anyChar
+               go (acc <> h <> fromChar c)
+             '"' -> (A.char '"' *> go (acc <> h <> fromChar '"'))
+                    <|> pure (acc <> h)
+             _ -> error "impossible in doubleQuoted"
+      rest
+
+-- | Generic range to builder for plain values
+rangeToBuilder :: (a -> Builder) -> PGRange a -> Builder
+rangeToBuilder _ EmptyRange = fromByteString "'empty'"
+rangeToBuilder _ (PGRange Nothing Nothing) = fromByteString "'[,)'"
+rangeToBuilder f (PGRange a b) = buildLB a <> buildUB b
+  where
+    buildLB Nothing = fromByteString "'[,"
+    buildLB (Just bound) = case bound of
+       Inclusive v -> fromByteString "'[\"" <> f v <> fromByteString "\","
+       Exclusive v -> fromByteString "'(\"" <> f v <> fromByteString "\","
+
+    buildUB Nothing = fromByteString "]'"
+    buildUB (Just bound) = case bound of
+        Inclusive v -> fromChar '"' <> f v <> fromByteString "\"]'"
+        Exclusive v -> fromChar '"' <> f v <> fromByteString "\")'"
+{-# INLINE rangeToBuilder #-}
+
+------ instances -----
+instance (FromField a, Typeable a) => FromField (PGRange a) where
+  fromField f mdat = do
+    info <- typeInfo f
+    case info of
+      Range{} ->
+        let f' = f { typeOid = typoid (rngsubtype info) }
+        in case mdat of
+          Nothing -> returnError UnexpectedNull f ""
+          Just "empty" -> pure $ EmptyRange
+          Just bs ->
+            let parseIt Nothing     = pure Nothing
+                parseIt (Just (Inclusive v)) = Just . Inclusive <$> fromField f' (Just v)
+                parseIt (Just (Exclusive v)) = Just . Exclusive <$> fromField f' (Just v)
+            in case parseOnly pgrange bs of
+                Left e -> returnError ConversionFailed f e
+                Right (lb,ub) -> PGRange <$> parseIt lb <*> parseIt ub
+      _ -> returnError Incompatible f ""
+
+
+-- | Generic range ToField function, useful if you want to define your own
+--   range types. Remember not to put your boundary value in quotes and
+--   escape double quotes.
+rangeToField :: (a -> Action) -> PGRange a -> Action
+rangeToField _ EmptyRange = Plain $ fromByteString "'empty'"
+rangeToField _ (PGRange Nothing Nothing) = Plain $ fromByteString "'[,)'"
+rangeToField f (PGRange a b) = Many $ buildLB a ++ buildUB b
+  where
+    buildLB Nothing     = [ Plain $ fromByteString "'(," ]
+    buildLB (Just bound) = case bound of
+        Inclusive v -> [ Plain $ fromByteString "'[\"", f v
+                       , Plain $ fromByteString "\"," ]
+        Exclusive v -> [ Plain $ fromByteString "'(\"", f v
+                       , Plain $ fromByteString "\"," ]
+    buildUB Nothing     = [ Plain $ fromByteString "]'"]
+    buildUB (Just bound) = case bound of
+        Inclusive v -> [ Plain $ fromChar '"', f v
+                       , Plain $ fromByteString "\"]'"]
+        Exclusive v -> [ Plain $ fromChar '"', f v
+                       , Plain $ fromByteString "\")'"]
+
+integralRangeToBuilder :: (Integral a, Show a) => PGRange a -> Builder
+integralRangeToBuilder = rangeToBuilder integral
+{-# INLINE integralRangeToBuilder #-}
+
+instance ToField (PGRange Int8) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Int16) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Int32) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Int) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Int64) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Integer) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Word8) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Word16) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Word32) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Word) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Word64) where
+    toField = Plain . integralRangeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Float) where
+    toField = Plain . rangeToBuilder float
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Double) where
+    toField = Plain . rangeToBuilder double
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Scientific) where
+    toField = Plain . rangeToBuilder f
+      where
+        f = fromLazyByteString . LT.encodeUtf8 . LT.toLazyText . scientificBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange UTCTime) where
+    toField = Plain . rangeToBuilder utcTimeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange ZonedTime) where
+    toField = Plain . rangeToBuilder zonedTimeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange LocalTime) where
+    toField = Plain . rangeToBuilder localTimeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Day) where
+    toField = Plain . rangeToBuilder dayToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange TimeOfDay) where
+    toField = Plain . rangeToBuilder timeOfDayToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange UTCTimestamp) where
+    toField = Plain . rangeToBuilder utcTimestampToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange ZonedTimestamp) where
+    toField = Plain . rangeToBuilder zonedTimestampToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange LocalTimestamp) where
+    toField = Plain . rangeToBuilder localTimestampToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange Date) where
+    toField = Plain . rangeToBuilder dateToBuilder
+    {-# INLINE toField #-}
+
+instance ToField (PGRange NominalDiffTime) where
+    toField = Plain . rangeToBuilder nominalDiffTimeToBuilder
+    {-# INLINE toField #-}

--- a/src/Database/PostgreSQL/Simple/Range/Simple.hs
+++ b/src/Database/PostgreSQL/Simple/Range/Simple.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.PostgreSQL.Simple.Range.Simple
+       where
+
+import           Control.Applicative
+import           Data.Maybe                                      (fromMaybe,
+                                                                  isNothing)
+import           Data.Typeable                                   (Typeable)
+
+import           Database.PostgreSQL.Simple.FromField            (FromField (..), ResultError (..),
+                                                                  returnError)
+import           Database.PostgreSQL.Simple.Range.Implementation (PGRange (..), RangeBound (..))
+import           Database.PostgreSQL.Simple.ToField              (ToField (..))
+-- | Simple range type for not empty ranges alway inclusive on
+-- lower-bound and exclusive on upper bound @[lower-bound,upper-bound)@
+data SimpleRange a = SimpleRange (Maybe a) (Maybe a)
+     deriving (Show, Typeable, Eq, Ord, Functor)
+
+-- | convert 'SimpleRange' to 'PGRange'
+simpleToRange :: SimpleRange a -> PGRange a
+simpleToRange (SimpleRange a b) = PGRange (Inclusive <$> a) (Exclusive <$> b)
+{-# INLINE simpleToRange #-}
+
+-- | try to convert 'PGRange' to 'SimpleRange' if it can be represented as such
+mayToSimpleRange :: PGRange a -> Maybe (SimpleRange a)
+mayToSimpleRange (PGRange a b) = SimpleRange <$> low <*> up
+  where
+    low = case a of
+      Nothing -> Just Nothing
+      (Just (Inclusive v)) -> Just (Just v)
+      _ -> Nothing
+    up = case b of
+      Nothing -> Just Nothing
+      (Just (Exclusive v)) -> Just (Just v)
+      _ -> Nothing
+mayToSimpleRange _ = Nothing
+
+-- | Convert non empty range to canonicalized discrete @[lower,upper)@ range
+mayToDiscreteRange :: Enum a => PGRange a -> Maybe (SimpleRange a)
+mayToDiscreteRange (PGRange a b) = Just $ SimpleRange (fmap toLow a) (fmap toUp b)
+  where
+    toLow (Exclusive v) = pred v
+    toLow (Inclusive v) = v
+    toUp (Exclusive v) = v
+    toUp (Inclusive v) = succ v
+mayToDiscreteRange _ = Nothing
+
+-- | Build simple range from bounds, fixing order. Nothing for empty range
+simpleRange :: Ord a => a -> a -> Maybe (SimpleRange a)
+simpleRange a b = case compare a b of
+   LT -> Just $ SimpleRange (Just a) (Just b)
+   GT -> Just $ SimpleRange (Just b) (Just a)
+   EQ -> Nothing
+
+-- | Build simple range from bounds, fixing order. errors on empty range
+simpleRangeErr :: Ord a => a -> a -> SimpleRange a
+simpleRangeErr a b = case compare a b of
+   LT -> SimpleRange (Just a) (Just b)
+   GT -> SimpleRange (Just b) (Just a)
+   EQ -> error "simpleRangeErr results in empty range"
+
+-- | Is range unbounded on both ends
+isInfiniteRange :: SimpleRange a -> Bool
+isInfiniteRange (SimpleRange Nothing Nothing) = True
+isInfiniteRange _ = False
+
+-- | @lower_inf@ in postgres
+isLowerInfinite :: SimpleRange a -> Bool
+isLowerInfinite (SimpleRange Nothing _) = True
+isLowerInfinite _ = False
+
+-- | @upper_inf@ in postgres
+isUpperInfinite :: SimpleRange a -> Bool
+isUpperInfinite (SimpleRange _ Nothing) = True
+isUpperInfinite _ = False
+
+-- | @lower@ in postgres
+lowerBound :: SimpleRange a -> Maybe a
+lowerBound (SimpleRange l _ ) = l
+
+-- | @upper@ in postgres
+upperBound :: SimpleRange a -> Maybe a
+upperBound (SimpleRange _ u ) = u
+
+
+-- | (@\@>@)
+containsElem :: Ord a => SimpleRange a -> a -> Bool
+containsElem (SimpleRange Nothing  Nothing)  _ = True
+containsElem (SimpleRange (Just l) Nothing)  e = e >= l
+containsElem (SimpleRange Nothing  (Just r)) e = e < r
+containsElem (SimpleRange (Just l) (Just r)) e = e >= l && e < r
+
+-- | (@\@>@) for ranges
+containsRange :: Ord a => SimpleRange a -> SimpleRange a -> Bool
+containsRange a b = withinLeftBoundOf b a && withinRightBoundOf b a
+
+-- | @&&@ - do ranges have points in common
+overlaps :: Ord a => SimpleRange a -> SimpleRange a -> Bool
+overlaps (SimpleRange ll lr) (SimpleRange rl rr) = left && right
+  where
+    left = case ll of
+      Nothing -> True
+      Just v -> fromMaybe True $ (v <=) <$> rr
+    right = case lr of
+      Nothing -> True
+      Just v -> fromMaybe True $ (v >=) <$> rl
+
+-- | @<<@ is strictly left of
+isLeftOf :: Ord a => SimpleRange a -> SimpleRange a -> Bool
+isLeftOf _ (SimpleRange Nothing _) = False
+isLeftOf (SimpleRange _ Nothing) _ = False
+isLeftOf (SimpleRange _ (Just l)) (SimpleRange (Just r) _) = l <= r
+
+-- | @<<@ is strictly right of
+isRightOf :: Ord a => SimpleRange a -> SimpleRange a -> Bool
+isRightOf _ (SimpleRange _ Nothing) = False
+isRightOf (SimpleRange Nothing _) _ = False
+isRightOf (SimpleRange (Just l) _) (SimpleRange _ (Just r)) = l > r
+
+-- | @&<@ does not extend to the right of
+withinRightBoundOf :: Ord a => SimpleRange a -> SimpleRange a -> Bool
+withinRightBoundOf (SimpleRange _ Nothing) (SimpleRange _ r) = isNothing r
+withinRightBoundOf (SimpleRange _ (Just v)) (SimpleRange _ r) = fromMaybe True $ (v <= ) <$> r
+
+-- | @&>@ does not extend to the left of
+withinLeftBoundOf :: Ord a => SimpleRange a -> SimpleRange a -> Bool
+withinLeftBoundOf (SimpleRange Nothing _) (SimpleRange r _) = isNothing r
+withinLeftBoundOf (SimpleRange (Just v) _) (SimpleRange r _) = fromMaybe True $ (v >= ) <$> r
+
+-- | Right bound equals left bound of other range
+adjacentToLeftOf :: Eq a => SimpleRange a -> SimpleRange a -> Bool
+adjacentToLeftOf (SimpleRange _ Nothing) _ = False
+adjacentToLeftOf _ (SimpleRange Nothing _) = False
+adjacentToLeftOf (SimpleRange _ (Just l)) (SimpleRange (Just r) _) = l == r
+
+-- | Left bound equals right bound of other range
+adjacentToRightOf :: Eq a => SimpleRange a -> SimpleRange a -> Bool
+adjacentToRightOf (SimpleRange Nothing _) _ = False
+adjacentToRightOf _ (SimpleRange _ Nothing) = False
+adjacentToRightOf (SimpleRange (Just l) _) (SimpleRange _ (Just r)) = l == r
+
+-- | Either left or right bound is adjacent to other range
+adjacentTo :: Eq a => SimpleRange a -> SimpleRange a -> Bool
+adjacentTo l r = adjacentToLeftOf l r && adjacentToRightOf l r
+
+
+instance (ToField (PGRange a)) => ToField (SimpleRange a) where
+  toField = toField . simpleToRange
+  {-# INLINE toField #-}
+
+instance (Typeable a, FromField (PGRange a)) => FromField (SimpleRange a) where
+  fromField f mb = do
+     pgr <- fromField f mb
+     case pgr of
+       EmptyRange -> returnError ConversionFailed f "Empty range encountered"
+       PGRange l r -> do
+         leftB <- case l of
+           Nothing -> return Nothing
+           (Just (Inclusive v)) -> return $ Just v
+           _ -> returnError ConversionFailed f "Exclusive left bound encountered"
+         rightB <- case r of
+           Nothing -> return Nothing
+           (Just (Exclusive v)) -> return $ Just v
+           _ -> returnError ConversionFailed f "Inclusive right bound encountered"
+         return $ SimpleRange leftB rightB
+  {-# INLINE fromField #-}

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -1,5 +1,8 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor  #-}
-{-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 ------------------------------------------------------------------------------
 -- |
@@ -22,12 +25,6 @@ module Database.PostgreSQL.Simple.ToField
     , inQuotes
     ) where
 
-<<<<<<< HEAD
-=======
-import Blaze.ByteString.Builder (Builder, fromByteString, toByteString)
-import Blaze.ByteString.Builder.Char8 (fromChar)
-import Blaze.Text (integral, double, float)
->>>>>>> Another take on ranges
 import qualified Data.Aeson as JSON
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DeriveDataTypeable   #-}
-{-# LANGUAGE DeriveFunctor        #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor  #-}
+{-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 
 ------------------------------------------------------------------------------
 -- |
@@ -25,9 +20,14 @@ module Database.PostgreSQL.Simple.ToField
     , ToField(..)
     , toJSONField
     , inQuotes
-    , rangeToField
     ) where
 
+<<<<<<< HEAD
+=======
+import Blaze.ByteString.Builder (Builder, fromByteString, toByteString)
+import Blaze.ByteString.Builder.Char8 (fromChar)
+import Blaze.Text (integral, double, float)
+>>>>>>> Another take on ranges
 import qualified Data.Aeson as JSON
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder
@@ -52,14 +52,12 @@ import qualified Data.Text as ST
 import qualified Data.Text.Encoding as ST
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Builder as LT
-import qualified Data.Text.Lazy.Encoding as LT
 import           Data.UUID   (UUID)
 import qualified Data.UUID as UUID
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import qualified Database.PostgreSQL.LibPQ as PQ
 import           Database.PostgreSQL.Simple.Time
-import           Database.PostgreSQL.Simple.Range
 import           Data.Scientific (Scientific)
 #if MIN_VERSION_scientific(0,3,0)
 import           Data.Text.Lazy.Builder.Scientific (scientificBuilder)
@@ -289,125 +287,6 @@ instance (ToField a) => ToField (PGArray a) where
 
 instance (ToField a) => ToField (Vector a) where
     toField = toField . PGArray . V.toList
-
--- | Generic range ToField function, useful if you want to define your own
---   range types. Remember not to put your boundary value in quotes and
---   escape double quotes.
-rangeToField :: (a -> Action) -> PGRange a -> Action
-rangeToField _ (PGRange Unbounded Unbounded) = Plain $ fromByteString "'empty'"
-rangeToField f (PGRange a b) = Many $ buildLB a ++ buildUB b
-  where
-    buildLB Unbounded     = [ Plain $ fromByteString "'(," ]
-    buildLB (Inclusive v) = [ Plain $ fromByteString "'[\"", f v
-                            , Plain $ fromByteString "\"," ]
-    buildLB (Exclusive v) = [ Plain $ fromByteString "'(\"", f v
-                            , Plain $ fromByteString "\"," ]
-    buildUB Unbounded     = [ Plain $ fromByteString "]'"]
-    buildUB (Inclusive v) = [ Plain $ fromChar '"', f v
-                            , Plain $ fromByteString "\"]'"]
-    buildUB (Exclusive v) = [ Plain $ fromChar '"', f v
-                            , Plain $ fromByteString "\")'"]
-integralRangeToBuilder :: (Integral a, Show a) => PGRange a -> Builder
-integralRangeToBuilder = rangeToBuilder integral
-{-# INLINE integralRangeToBuilder #-}
-
-instance ToField (PGRange Int8) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Int16) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Int32) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Int) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Int64) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Integer) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Word8) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Word16) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Word32) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Word) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Word64) where
-    toField = Plain . integralRangeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Float) where
-    toField = Plain . rangeToBuilder float
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Double) where
-    toField = Plain . rangeToBuilder double
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Scientific) where
-    toField = Plain . rangeToBuilder f
-      where
-        f = fromLazyByteString . LT.encodeUtf8 . LT.toLazyText . scientificBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange UTCTime) where
-    toField = Plain . rangeToBuilder utcTimeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange ZonedTime) where
-    toField = Plain . rangeToBuilder zonedTimeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange LocalTime) where
-    toField = Plain . rangeToBuilder localTimeToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Day) where
-    toField = Plain . rangeToBuilder dayToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange TimeOfDay) where
-    toField = Plain . rangeToBuilder timeOfDayToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange UTCTimestamp) where
-    toField = Plain . rangeToBuilder utcTimestampToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange ZonedTimestamp) where
-    toField = Plain . rangeToBuilder zonedTimestampToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange LocalTimestamp) where
-    toField = Plain . rangeToBuilder localTimestampToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange Date) where
-    toField = Plain . rangeToBuilder dateToBuilder
-    {-# INLINE toField #-}
-
-instance ToField (PGRange NominalDiffTime) where
-    toField = Plain . rangeToBuilder nominalDiffTimeToBuilder
-    {-# INLINE toField #-}
 
 instance ToField UUID where
     toField = Plain . inQuotes . byteString . UUID.toASCIIBytes


### PR DESCRIPTION
Range types were added to base postgres in 9.2

Separate instances for different kinds of elements are required because of range syntax. Values can be quoted in double quotes
but not in single quotes. Thus double, float, various date and time ToField instances can't be used.

I'm not sure about code organization, and willing to change it if needed. Where to put PGRange type? Should it be exported by default?
Why Arrays module exports internal things? Should I do the same?

So, I'm willing to clean up this if needed