### PR TITLE
Don't require OverloadedStrings by explicitly calling fromString.

### DIFF
--- a/src/Database/PostgreSQL/Simple/SqlQQ.hs
+++ b/src/Database/PostgreSQL/Simple/SqlQQ.hs
@@ -10,7 +10,7 @@
 ------------------------------------------------------------------------------
 
 module Database.PostgreSQL.Simple.SqlQQ (sql) where
-
+import Database.PostgreSQL.Simple.Types (Query)
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 import Data.Char
@@ -62,7 +62,7 @@ sql = QuasiQuoter
     }
 
 sqlExp :: String -> Q Exp
-sqlExp = appE [| fromString  |] . stringE . minimizeSpace
+sqlExp = appE [| fromString :: String -> Query |] . stringE . minimizeSpace
 
 minimizeSpace :: String -> String
 minimizeSpace = drop 1 . reduceSpace

--- a/src/Database/PostgreSQL/Simple/SqlQQ.hs
+++ b/src/Database/PostgreSQL/Simple/SqlQQ.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 ------------------------------------------------------------------------------
 -- |
 -- Module:      Database.PostgreSQL.Simple.SqlQQ
@@ -13,6 +14,7 @@ module Database.PostgreSQL.Simple.SqlQQ (sql) where
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 import Data.Char
+import Data.String
 
 -- | 'sql' is a quasiquoter that eases the syntactic burden
 -- of writing big sql statements in Haskell source code.  For example:
@@ -60,7 +62,7 @@ sql = QuasiQuoter
     }
 
 sqlExp :: String -> Q Exp
-sqlExp = stringE . minimizeSpace
+sqlExp = appE [| fromString  |] . stringE . minimizeSpace
 
 minimizeSpace :: String -> String
 minimizeSpace = drop 1 . reduceSpace


### PR DESCRIPTION
Since adding calls to `fromString` is how `OverloadedStrings` works anyway, this is a pretty innocuous change.

(edit: oops, that's some cruddy english in the commit there... it's getting rather late I suppose)