### PR TITLE
initial support for using foundationdb

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -18,6 +18,9 @@ extra-source-files:
      CONTRIBUTORS
 
 Library
+  if flag(foundationdb)
+    cpp-options: -DFOUNDATIONDB
+
   hs-source-dirs: src
   Exposed-modules:
      Database.PostgreSQL.Simple
@@ -84,9 +87,14 @@ source-repository this
   location: http://github.com/lpsmith/postgresql-simple
   tag:      v0.4.8.0
 
-test-suite test
-  type:           exitcode-stdio-1.0
+flag foundationdb
+  description: run tests against FoundationDB instead of PostgresSQL
 
+test-suite test
+  if flag(foundationdb)
+    cpp-options: -DFOUNDATIONDB
+
+  type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        Main.hs
   other-modules:
@@ -115,3 +123,4 @@ test-suite test
                , text
                , time
                , vector
+               , transformers

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -420,6 +420,7 @@ query_ = queryWith_ fromRow
 -- | A version of 'query' taking parser as argument
 queryWith :: ToRow q => RowParser r -> Connection -> Query -> q -> IO [r]
 queryWith parser conn template qs = do
+  -- liftIO $ print =<< formatQuery conn template qs
   result <- exec conn =<< formatQuery conn template qs
   finishQueryWith parser conn template result
 

--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -196,10 +196,12 @@ connectPostgreSQL connstr = do
           connectionTempNameCounter <- newIORef 0
           let wconn = Connection{..}
           version <- PQ.serverVersion conn
+#ifndef FOUNDATIONDB
           let settings
                 | version < 80200 = "SET datestyle TO ISO"
                 | otherwise       = "SET standard_conforming_strings TO on;SET datestyle TO ISO"
           _ <- execute_ wconn settings
+#endif
           return wconn
       _ -> do
           msg <- maybe "connectPostgreSQL error" id <$> PQ.errorMessage conn
@@ -286,6 +288,7 @@ exec conn sql =
           Just res -> return res
 #else
 exec conn sql =
+    -- print sql
     withConnection conn $ \h -> do
         success <- PQ.sendQuery h sql
         if success

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -303,6 +303,13 @@ interleaveFoldr :: (a -> [b] -> [b]) -> b -> [b] -> [a] -> [b]
 interleaveFoldr f b bs as = foldr (\a bs -> b : f a bs) bs as
 {-# INLINE interleaveFoldr #-}
 
+#ifdef FOUNDATIONDB
+typeForCastExpr :: QualifiedIdentifier -> Action
+-- don't quote a type in a CAST expression
+typeForCastExpr (QualifiedIdentifier Nothing  t) = Plain $ fromByteString (ST.encodeUtf8 t)
+typeForCastExpr q = toField q
+#endif
+
 instance ToRow a => ToField (Values a) where
     toField (Values types rows) =
         case rows of
@@ -323,7 +330,13 @@ instance ToRow a => ToField (Values a) where
         values x = Many (lit "(VALUES ": x)
 
         typedField :: (Action, QualifiedIdentifier) -> [Action] -> [Action]
-        typedField (val,typ) rest = val : lit "::" : toField typ : rest
+        typedField (val,typ) rest =
+#ifdef FOUNDATIONDB
+            lit "CAST(" :  val : lit " AS " : typeForCastExpr typ : litC ')'
+#else
+            val : lit "::" : toField typ
+#endif
+              : rest
 
         typedRow :: [Action] -> [QualifiedIdentifier] -> [Action] -> [Action]
         typedRow (val:vals) (typ:typs) rest =


### PR DESCRIPTION
FoundationDB is a modern database with a focus on perfecting distributed transactions and fault tolerance (the hard stuff).
On top of that, they build layers, including a [SQL Layer](https://foundationdb.com/layers/sql).
The SQL Layer speaks the PostgresSQL protocol and works with libpq.

This patch adds a foundatbiondb flag that sets up CPP.
It CPP removes some connection initialization code and code to set the isolation level.
Isolation levels are not needed in FoundationDB because every transaction has a [serializeable isolation level](http://blog.foundationdb.com/whiteboard-series-isolation).

Most of the test cases are PostgresSQL specific and thus are removed with CPP.
The few that are left show that binary serialization definitely has issues.
There are probably some other similar issues to fix around data types.