### PR TITLE
Use 'uuid-types' instead of 'uuid'

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -64,7 +64,7 @@ Library
     text >= 0.11.1,
     time,
     transformers,
-    uuid >= 1.3.1,
+    uuid-types >= 1.0.0,
     scientific,
     vector
 

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -145,8 +145,8 @@ import qualified Data.Text.Encoding as ST
 import qualified Data.Text.Lazy as LT
 import           Data.CaseInsensitive (CI)
 import qualified Data.CaseInsensitive as CI
-import           Data.UUID   (UUID)
-import qualified Data.UUID as UUID
+import           Data.UUID.Types   (UUID)
+import qualified Data.UUID.Types as UUID
 import           Data.Scientific (Scientific)
 import           GHC.Real (infinity, notANumber)
 

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -46,8 +46,8 @@ import qualified Data.Text as ST
 import qualified Data.Text.Encoding as ST
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Builder as LT
-import           Data.UUID   (UUID)
-import qualified Data.UUID as UUID
+import           Data.UUID.Types   (UUID)
+import qualified Data.UUID.Types as UUID
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import qualified Database.PostgreSQL.LibPQ as PQ


### PR DESCRIPTION
In the interest of reducing dependencies, I'd like to change postgresql-simple over from `uuid` to `uuid-types` -- which were split into two for this very purpose :).

I *think* this should be completely backward compatible since `uuid` just reexports Data.UUID.Types.UUID under the old name Data.UUID.UUID. All the relevant type class instances are the same as they were in the older `uuid-types`.

Commit message below:

This reduces the number of transitive dependencies, getting rid of
e.g. "cryptohash", "network-info" and "time".