### PR TITLE
Implement default instances for {To,From}Row using Generic

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -53,7 +53,7 @@ Library
   Build-depends:
     aeson >= 0.6,
     attoparsec >= 0.10.3,
-    base < 5,
+    base >= 4.4 && < 5,
     bytestring >= 0.9,
     bytestring-builder,
     case-insensitive,

--- a/src/Database/PostgreSQL/Simple/ToRow.hs-boot
+++ b/src/Database/PostgreSQL/Simple/ToRow.hs-boot
@@ -1,9 +1,18 @@
-module Database.PostgreSQL.Simple.ToRow where
+{-# LANGUAGE DefaultSignatures, FlexibleInstances, FlexibleContexts #-}
+module Database.PostgreSQL.Simple.ToRow (
+      ToRow(..)
+    ) where
 
 import Database.PostgreSQL.Simple.Types
 import {-# SOURCE #-} Database.PostgreSQL.Simple.ToField
+import GHC.Generics
 
 class ToRow a where
     toRow :: a -> [Action]
+    default toRow :: (Generic a, GToRow (Rep a)) => a -> [Action]
+    toRow = gtoRow . from
+
+class GToRow f where
+    gtoRow :: f p -> [Action]
 
 instance ToField a => ToRow (Only a)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -46,7 +46,6 @@ tests =
     , TestLabel "Values"        . testValues
     , TestLabel "Copy"          . testCopy
     , TestLabel "Double"        . testDouble
-    , TestLabel "0-ary generic" . testGeneric0
     , TestLabel "1-ary generic" . testGeneric1
     , TestLabel "2-ary generic" . testGeneric2
     , TestLabel "3-ary generic" . testGeneric3
@@ -323,11 +322,6 @@ testDouble TestEnv{..} = TestCase $ do
     [Only (x :: Double)] <- query_ conn "SELECT '-Infinity'::float8"
     x @?= (-1 / 0)
 
-testGeneric0 :: TestEnv -> Test
-testGeneric0 TestEnv{..} = TestCase $ do
-    let x0 = Gen0
-    r <- query conn "SELECT" x0
-    r @?= [x0]
 
 testGeneric1 :: TestEnv -> Test
 testGeneric1 TestEnv{..} = TestCase $ do
@@ -346,11 +340,6 @@ testGeneric3 TestEnv{..} = TestCase $ do
     let x0 = Gen3 123 "asdf" True
     r <- query conn "SELECT ?::int, ?::text, ?::bool" x0
     r @?= [x0]
-
-data Gen0 = Gen0
-            deriving (Show,Eq,Generic)
-instance FromRow Gen0
-instance ToRow   Gen0
 
 data Gen1 = Gen1 Int
             deriving (Show,Eq,Generic)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,6 +24,7 @@ import System.Exit (exitFailure)
 import System.IO
 import qualified Data.Vector as V
 import Data.Aeson
+import GHC.Generics (Generic)
 
 import Notify
 import Serializable
@@ -44,6 +46,10 @@ tests =
     , TestLabel "Values"        . testValues
     , TestLabel "Copy"          . testCopy
     , TestLabel "Double"        . testDouble
+    , TestLabel "0-ary generic" . testGeneric0
+    , TestLabel "1-ary generic" . testGeneric1
+    , TestLabel "2-ary generic" . testGeneric2
+    , TestLabel "3-ary generic" . testGeneric3
     ]
 
 testBytea :: TestEnv -> Test
@@ -317,6 +323,49 @@ testDouble TestEnv{..} = TestCase $ do
     [Only (x :: Double)] <- query_ conn "SELECT '-Infinity'::float8"
     x @?= (-1 / 0)
 
+testGeneric0 :: TestEnv -> Test
+testGeneric0 TestEnv{..} = TestCase $ do
+    let x0 = Gen0
+    r <- query conn "SELECT ?::int" x0
+    r @?= [x0]
+
+testGeneric1 :: TestEnv -> Test
+testGeneric1 TestEnv{..} = TestCase $ do
+    let x0 = Gen1 123
+    r <- query conn "SELECT ?::int" x0
+    r @?= [x0]
+
+testGeneric2 :: TestEnv -> Test
+testGeneric2 TestEnv{..} = TestCase $ do
+    let x0 = Gen2 123 "asdf"
+    r <- query conn "SELECT ?::int" x0
+    r @?= [x0]
+
+testGeneric3 :: TestEnv -> Test
+testGeneric3 TestEnv{..} = TestCase $ do
+    let x0 = Gen3 123 "asdf" True
+    r <- query conn "SELECT ?::int" x0
+    r @?= [x0]
+
+data Gen0 = Gen0
+            deriving (Show,Eq,Generic)
+instance FromRow Gen0
+instance ToRow   Gen0
+
+data Gen1 = Gen1 Int
+            deriving (Show,Eq,Generic)
+instance FromRow Gen1
+instance ToRow   Gen1
+
+data Gen2 = Gen2 Int Text
+            deriving (Show,Eq,Generic)
+instance FromRow Gen2
+instance ToRow   Gen2
+
+data Gen3 = Gen3 Int Text Bool
+            deriving (Show,Eq,Generic)
+instance FromRow Gen3
+instance ToRow   Gen3
 
 data TestException
   = TestException

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -326,7 +326,7 @@ testDouble TestEnv{..} = TestCase $ do
 testGeneric0 :: TestEnv -> Test
 testGeneric0 TestEnv{..} = TestCase $ do
     let x0 = Gen0
-    r <- query conn "SELECT ?::int" x0
+    r <- query conn "SELECT" x0
     r @?= [x0]
 
 testGeneric1 :: TestEnv -> Test
@@ -338,13 +338,13 @@ testGeneric1 TestEnv{..} = TestCase $ do
 testGeneric2 :: TestEnv -> Test
 testGeneric2 TestEnv{..} = TestCase $ do
     let x0 = Gen2 123 "asdf"
-    r <- query conn "SELECT ?::int" x0
+    r <- query conn "SELECT ?::int, ?::text" x0
     r @?= [x0]
 
 testGeneric3 :: TestEnv -> Test
 testGeneric3 TestEnv{..} = TestCase $ do
     let x0 = Gen3 123 "asdf" True
-    r <- query conn "SELECT ?::int" x0
+    r <- query conn "SELECT ?::int, ?::text, ?::bool" x0
     r @?= [x0]
 
 data Gen0 = Gen0


### PR DESCRIPTION
Writing instance for {To,From}Row is verbose, tedious, and should be left to compiler. I wrote deriving of such instances using Generic. I've also put lower bound on base (GHC>=7.2 when Generics appeared)

There's no tests. I couldn't figure out how to run RowParser on [Field]