### PR TITLE
fix cmp fn in rangeToBuilderBy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: haskell
 
+ghc:
+  - 7.6
+  - 7.8
+
 addons:
   postgresql: "9.3"
 

--- a/src/Database/PostgreSQL/Simple/Range.hs
+++ b/src/Database/PostgreSQL/Simple/Range.hs
@@ -132,7 +132,7 @@ rangeToBuilder :: Ord a => (a -> Builder) -> PGRange a -> Builder
 rangeToBuilder = rangeToBuilderBy compare
 
 -- | Generic range to builder for plain values
-rangeToBuilderBy :: (a -> a -> Ordering) => (a -> Builder) -> PGRange a -> Builder
+rangeToBuilderBy :: (a -> a -> Ordering) -> (a -> Builder) -> PGRange a -> Builder
 rangeToBuilderBy cmp f x =
     if isEmptyBy cmp x
     then byteString "'empty'"


### PR DESCRIPTION
The package fails to build with GHC 7.8, because of a typo in `rangeToBuilderBy` where a `=>` is used instead of `->`.