### PR TITLE
fix FromField Value so it accepts not only top-level json values

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -184,6 +184,8 @@ testJSON TestEnv{..} = TestCase $ do
     roundTrip (Map.fromList [("foo","bar"),("bar","baz"),("baz","hello")] :: Map Text Text)
     roundTrip (Map.fromList [("fo\"o","bar"),("b\\ar","baz"),("baz","\"value\\with\"escapes")] :: Map Text Text)
     roundTrip (V.fromList [1,2,3,4,5::Int])
+    roundTrip ("foo" :: Text)
+    roundTrip (42 :: Int)
   where
     roundTrip :: ToJSON a => a -> Assertion
     roundTrip a = do


### PR DESCRIPTION
The `ToField Value` instance currently accepts every JSON value (e.g. string or number values), and in fact this is also what the postgres JSON field supports. But when trying to retrieve such a non-top-level (neither array nor object) value, the `FromField Value` instance fails, because it uses the default aeson parser which only accepts top-level values.

This fix changes the `FromField Value` instance to accept any JSON value, and thus completes the identity between `fromField` and `toField`.