### PR TITLE
Add Cube type for insertion

### DIFF
--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -60,6 +60,7 @@ module Database.PostgreSQL.Simple
     , ToRow
     , FromRow
     , In(..)
+    , Cube(..)
     , Binary(..)
     , Only(..)
     , (:.)(..)
@@ -134,7 +135,7 @@ import           Database.PostgreSQL.Simple.Ok
 import           Database.PostgreSQL.Simple.ToField (Action(..))
 import           Database.PostgreSQL.Simple.ToRow (ToRow(..))
 import           Database.PostgreSQL.Simple.Types
-                   ( Binary(..), In(..), Only(..), Query(..), (:.)(..) )
+                   ( Binary(..), In(..), Cube(..), Only(..), Query(..), (:.)(..) )
 import           Database.PostgreSQL.Simple.Internal as Base
 import           Database.PostgreSQL.Simple.Transaction
 import           Database.PostgreSQL.Simple.TypeInfo

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -31,7 +31,7 @@ import           Data.ByteString.Builder
                    , floatDec, doubleDec
                    )
 import Data.Int (Int8, Int16, Int32, Int64)
-import Data.List (intersperse)
+import Data.List (intersperse, intercalate)
 import Data.Monoid (mappend)
 import Data.Time (Day, TimeOfDay, LocalTime, UTCTime, ZonedTime, NominalDiffTime)
 import Data.Typeable (Typeable)
@@ -366,3 +366,13 @@ instance ToRow a => ToField (Values a) where
                                 (litC ',')
                                 rest
                                 vals
+
+instance ToField Cube where
+    toField (Cube cs) = Many $
+        Plain (byteString "CUBE('") :
+        (intercalate [comma] $ map point cs) ++
+        [Plain (byteString "')")]
+            where comma = Plain (char8 ',')
+                  point lst = Plain (char8 '(') :
+                              (intersperse comma $ map toField lst) ++
+                              [Plain (char8 ')')]

--- a/src/Database/PostgreSQL/Simple/Types.hs
+++ b/src/Database/PostgreSQL/Simple/Types.hs
@@ -19,6 +19,7 @@ module Database.PostgreSQL.Simple.Types
     , Default(..)
     , Only(..)
     , In(..)
+    , Cube(..)
     , Binary(..)
     , Identifier(..)
     , QualifiedIdentifier(..)
@@ -232,3 +233,5 @@ newtype Savepoint = Savepoint Query
 --   more information.
 data Values a = Values [QualifiedIdentifier] [a]
     deriving (Eq, Ord, Show, Read, Typeable)
+
+data Cube = Cube [[Float]]


### PR DESCRIPTION
- Add and export Cube type in Types.hs
- Add ToField instance for Cube in ToField.hs

This now supports inserting [`cube`s](http://www.postgresql.org/docs/9.1/static/cube.html).

I didn't add a `FromField` because it looks non-trivial, and I don't need it for my use case (though if you could point me to docs on defining one, I wouldn't mind giving it a shot).

Also, not sure I added these to the best places. Might be better organized as an `Extensions.hs` file somewhere so that extension-related types could be grouped together.