### PR TITLE
Raises lowerbound on bytestring package due to use of toStrict (only …

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -57,7 +57,7 @@ Library
     aeson >= 0.6,
     attoparsec >= 0.10.3,
     base < 5,
-    bytestring >= 0.9,
+    bytestring >= 0.10,
     bytestring-builder,
     case-insensitive,
     containers,


### PR DESCRIPTION
…publicly exposed in bytestring-0.10.0.0)

Noticed it when trying to bump bounds on the snaplet:

https://travis-ci.org/mightybyte/snaplet-postgresql-simple/jobs/84997385