### PR TITLE
PostgreSQL wants type information for `ARRAY[]`

### DIFF
--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -272,12 +272,15 @@ instance ToField NominalDiffTime where
     {-# INLINE toField #-}
 
 instance (ToField a) => ToField (PGArray a) where
-    toField xs = Many $
-        Plain (byteString "ARRAY[") :
-        (intersperse (Plain (char8 ',')) . map toField $ fromPGArray xs) ++
-        [Plain (char8 ']')]
-        -- Because the ARRAY[...] input syntax is being used, it is possible
-        -- that the use of type-specific separator characters is unnecessary.
+    toField pgArray =
+      case fromPGArray pgArray of
+        [] -> Plain (byteString "'{}'")
+        xs -> Many $
+          Plain (byteString "ARRAY[") :
+          (intersperse (Plain (char8 ',')) . map toField $ xs) ++
+          [Plain (char8 ']')]
+          -- Because the ARRAY[...] input syntax is being used, it is possible
+          -- that the use of type-specific separator characters is unnecessary.
 
 instance (ToField a) => ToField (Vector a) where
     toField = toField . PGArray . V.toList


### PR DESCRIPTION
While PostgreSQL does not require type information for the `ARRAY[]`
syntax when it is non-empty, empty arrays result in an error:

```
SqlError
  { sqlState = "42P18", sqlExecStatus = FatalError
  , sqlErrorMsg = "cannot determine type of empty array", sqlErrorDetail = ""
  , sqlErrorHint =
    "Explicitly cast to the desired type, for example ARRAY[]::integer[]."
  }
```

i.e. `ARRAY[1,2,3,4]` is correctly interpreted to be `integer[]`, but
`ARRAY[]` does not.

The syntax `'{}'` does not require type information when empty (for some
reason). Unfortunately, that syntax would require manual escaping for
non-empty arrays (e.g. if the elements have type `text`).

This commit simply special-cases the `ToField` instance of `PGArray`
when the array is empty to use the `{}` syntax.