### PR TITLE
Copy: Ensure that copy in requests finish before proceeding

### DIFF
--- a/src/Database/PostgreSQL/Simple/Copy.hs
+++ b/src/Database/PostgreSQL/Simple/Copy.hs
@@ -198,7 +198,9 @@ doCopyIn funcName action = loop
     loop pqconn = do
       stat <- action pqconn
       case stat of
-        PQ.CopyInOk    -> return ()
+        PQ.CopyInOk    -> do
+            res <- PQ.getResult pqconn
+            maybe (fail errCmdStatus) (const $ return ()) res
         PQ.CopyInError -> do
             mmsg <- PQ.errorMessage pqconn
             throwIO SqlError {
@@ -215,6 +217,7 @@ doCopyIn funcName action = loop
               Just fd -> do
                   threadWaitWrite fd
                   loop pqconn
+    errCmdStatus    = B.unpack funcName ++ ": failed to fetch command status"
 {-# INLINE doCopyIn #-}
 
 getCopyCommandTag :: B.ByteString -> PQ.Connection -> IO Int64


### PR DESCRIPTION
Although the documentation doesn't clearly state this, it turns out [1]
that it is necessary to request the status of a copy request after
PQputCopyEnd has returned successfully. Failing to do this will result
in later requests failing with "another command is already in progress".

[1] http://blog.endpoint.com/2011/05/dbdpg-and-libpq-copy-bug.html