### PR TITLE
Copy: Show error message on failure

### DIFF
--- a/src/Database/PostgreSQL/Simple/Copy.hs
+++ b/src/Database/PostgreSQL/Simple/Copy.hs
@@ -224,7 +224,9 @@ getCopyCommandTag funcName pqconn = do
     consumeResults pqconn
     let rowCount =   P.string "COPY " *> (P.decimal <* P.endOfInput)
     case P.parseOnly rowCount cmdStat of
-      Left  _ -> fail errCmdStatusFmt
+      Left  _ -> do mmsg <- PQ.errorMessage pqconn
+                    fail $ errCmdStatusFmt
+                        ++ maybe "" (\msg -> "\nConnection error: "++B.unpack msg) mmsg
       Right n -> return $! n
   where
     errCmdStatus    = B.unpack funcName ++ ": failed to fetch command status"


### PR DESCRIPTION
This ensures that the exception thrown includes the cause of the error. Sadly it seems that the only way to determine that a COPY IN has failed is to fail to parse the row count (as the result status is typically an empty string. It seems that all of the getResults calls after the putCopyEnd command inexplicably return success, despite the fact that something failed.
