### PR TITLE
Add interval Type

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -475,6 +475,10 @@ instance FromField LocalTimestamp where
 instance FromField Date where
   fromField = ff $(inlineTypoid TI.date) "Date" parseDate
 
+-- | interval
+instance FromField Interval where
+  fromField = ff $(inlineTypoid TI.interval) "Interval" parseInterval
+
 ff :: PQ.Oid -> String -> (B8.ByteString -> Either String a)
    -> Field -> Maybe B8.ByteString -> Conversion a
 ff compatOid hsType parse f mstr =

--- a/src/Database/PostgreSQL/Simple/Time.hs
+++ b/src/Database/PostgreSQL/Simple/Time.hs
@@ -218,6 +218,8 @@ module Database.PostgreSQL.Simple.Time
      , UTCTimestamp
      , ZonedTimestamp
      , LocalTimestamp
+     , Interval(..)
+     , zeroInterval
      , parseDay
      , parseUTCTime
      , parseZonedTime
@@ -227,6 +229,7 @@ module Database.PostgreSQL.Simple.Time
      , parseUTCTimestamp
      , parseZonedTimestamp
      , parseLocalTimestamp
+     , parseInterval
      , dayToBuilder
      , utcTimeToBuilder
      , zonedTimeToBuilder
@@ -239,6 +242,8 @@ module Database.PostgreSQL.Simple.Time
      , localTimestampToBuilder
      , unboundedToBuilder
      , nominalDiffTimeToBuilder
+     , intervalBuilder
      ) where
 
 import Database.PostgreSQL.Simple.Time.Implementation
+import Database.PostgreSQL.Simple.Time.Interval

--- a/src/Database/PostgreSQL/Simple/Time/Implementation.hs
+++ b/src/Database/PostgreSQL/Simple/Time/Implementation.hs
@@ -23,6 +23,7 @@ import Data.Typeable
 import Data.Maybe (fromMaybe)
 import qualified Data.Attoparsec.ByteString.Char8 as A
 import Database.PostgreSQL.Simple.Compat ((<>))
+import Database.PostgreSQL.Simple.Time.Interval (Interval)
 import qualified Database.PostgreSQL.Simple.Time.Internal.Parser  as TP
 import qualified Database.PostgreSQL.Simple.Time.Internal.Printer as TPP
 
@@ -49,6 +50,9 @@ type LocalTimestamp = Unbounded LocalTime
 type UTCTimestamp   = Unbounded UTCTime
 type ZonedTimestamp = Unbounded ZonedTime
 type Date           = Unbounded Day
+
+parseInterval :: B.ByteString -> Either String Interval
+parseInterval = A.parseOnly TP.interval
 
 parseUTCTime   :: B.ByteString -> Either String UTCTime
 parseUTCTime   = A.parseOnly (getUTCTime <* A.endOfInput)
@@ -164,3 +168,6 @@ dateToBuilder  = unboundedToBuilder dayToBuilder
 
 nominalDiffTimeToBuilder :: NominalDiffTime -> Builder
 nominalDiffTimeToBuilder = TPP.nominalDiffTime
+
+intervalBuilder :: Interval -> Builder
+intervalBuilder = TPP.interval

--- a/src/Database/PostgreSQL/Simple/Time/Interval.hs
+++ b/src/Database/PostgreSQL/Simple/Time/Interval.hs
@@ -1,0 +1,11 @@
+module Database.PostgreSQL.Simple.Time.Interval where
+
+import Data.Int
+
+data Interval = Interval { intervalMonths :: Int32
+                         , intervalDays :: Int32
+                         , intervalMicroseconds :: Integer }
+                         deriving (Show, Read, Eq)
+
+zeroInterval :: Interval
+zeroInterval = Interval 0 0 0

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -271,6 +271,10 @@ instance ToField NominalDiffTime where
     toField = Plain . inQuotes . nominalDiffTimeToBuilder
     {-# INLINE toField #-}
 
+instance ToField Interval where
+    toField = Plain . inQuotes . intervalBuilder
+    {-# INLINE toField #-}
+
 instance (ToField a) => ToField (PGArray a) where
     toField pgArray =
       case fromPGArray pgArray of

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -47,6 +47,7 @@ tests env = testGroup "tests"
     , testCase "Notify"             . testNotify
     , testCase "Serializable"       . testSerializable
     , testCase "Time"               . testTime
+    , testCase "Interval"           . testInterval
     , testCase "Array"              . testArray
     , testCase "Array of nullables" . testNullableArray
     , testCase "HStore"             . testHStore


### PR DESCRIPTION
I took a stab at adding an `Interval` ADT to this library as per this conversation:

https://github.com/lpsmith/postgresql-simple/issues/176

Let me know your thoughts or any changes you'd like to see. FYI I'm a bit unsure about the appropriate precision for the Interval's fields.

Although I'm testing against PostgreSQL 9.6.3 I appear to have run into this bug (or something similar):

https://www.postgresql.org/message-id/CAMWF=HS++N9-NKsh-o5QSymvp0Np-VB0GdWwAt4uie1h8ZdNTQ@mail.gmail.com

so the Interval builder splits microseconds back out into hours/minutes/seconds/microseconds to keep the numbers low.