### PR TITLE
Fix off-by-one error in year builder.

### DIFF
--- a/src/Database/PostgreSQL/Simple/Time/Internal/Printer.hs
+++ b/src/Database/PostgreSQL/Simple/Time/Internal/Printer.hs
@@ -71,7 +71,7 @@ frac = condB (== 0) emptyB ((,) '.' >$< (liftB char8 >*< trunc12))
 
 
 year  :: BoundedPrim Int32
-year = condB (> 10000) int32Dec (checkBCE >$< liftB digits4)
+year = condB (>= 10000) int32Dec (checkBCE >$< liftB digits4)
   where
     checkBCE :: Int32 -> Int
     checkBCE y


### PR DESCRIPTION
This bug bit me when I was stress-testing some event-generation code at my job. Before fixing this bug, I was getting this result:
`ghci λ: toField (fromGregorian 10000 1 1)`
`Plain "':000-01-01'"`
After the fix, it works like this:
`ghci λ: toField (fromGregorian 10000 1 1)`
`Plain "'10000-01-01'"`