### PR TITLE
Add support for CockroachDB

### DIFF
--- a/src/Database/PostgreSQL/Simple/Transaction.hs
+++ b/src/Database/PostgreSQL/Simple/Transaction.hs
@@ -176,7 +176,7 @@ withTransactionModeRetry mode shouldRetry conn act =
 
 -- | Rollback a transaction.
 rollback :: Connection -> IO ()
-rollback conn = execute_ conn "ABORT" >> return ()
+rollback conn = execute_ conn "ROLLBACK" >> return ()
 
 -- | Rollback a transaction, ignoring any @IOErrors@
 rollback_ :: Connection -> IO ()


### PR DESCRIPTION
This patch makes transaction handling and parsing compatible with [CockroachDB](https://github.com/cockroachdb/cockroach), which requires the SQL standard ROLLBACK command instead of the Postgres-specific ABORT and emits Date values with a trailing " 00:00:00".