### PR TITLE
Escape double '??' to a literal '?'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ matrix:
   include:
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
-      addons: { apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}, postgresql: "9.3"}
+      addons: { apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}, postgresql: "9.4"}
     - env: CABALVER=1.22 GHCVER=7.10.2
       compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}, postgresql: "9.3"}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}, postgresql: "9.4"}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}, postgresql: "9.3"}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}, postgresql: "9.4"}
 
 before_install:
  - unset CC

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -281,7 +281,7 @@ buildQuery :: Connection -> Query -> ByteString -> [Action] -> IO Builder
 buildQuery conn q template xs =
     zipParams (split template) <$> mapM (buildAction conn q xs) xs
   where split s =
-            let (h,t) = go (mempty,s)
+            let (h,t) = go (B.empty,s)
                 go (x,bs) = (x `B.append` x',bs')
                   where (h',t1) = B.break (=='?') bs
                         (x',bs') = maybe (h',t1) go2 $ B.uncons t1 >>= B.uncons . snd

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -281,11 +281,11 @@ buildQuery :: Connection -> Query -> ByteString -> [Action] -> IO Builder
 buildQuery conn q template xs =
     zipParams (split template) <$> mapM (buildAction conn q xs) xs
   where split s =
-            let (h,t) = go (B.mempty,s)
+            let (h,t) = go (mempty,s)
                 go (x,bs) = (x `B.append` x',bs')
                   where (h',t1) = B.break (=='?') bs
                         (x',bs') = maybe (h',t1) go2 $ B.uncons t1 >>= B.uncons . snd
-                        go2 ('?',t2) = go (h' `snoc` '?',t2)
+                        go2 ('?',t2) = go (h' `B.snoc` '?',t2)
                         go2 _ = (h',t1)
             in byteString h
                : if B.null t

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -281,7 +281,12 @@ buildQuery :: Connection -> Query -> ByteString -> [Action] -> IO Builder
 buildQuery conn q template xs =
     zipParams (split template) <$> mapM (buildAction conn q xs) xs
   where split s =
-            let (h,t) = B.break (=='?') s
+            let (h,t) = go (B.mempty,s)
+                go (x,bs) = (x `B.append` x',bs')
+                  where (h',t1) = B.break (=='?') bs
+                        (x',bs') = maybe (h',t1) go2 $ B.uncons t1 >>= B.uncons . snd
+                        go2 ('?',t2) = go (h' `snoc` '?',t2)
+                        go2 _ = (h',t1)
             in byteString h
                : if B.null t
                  then []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -238,25 +238,27 @@ testJSON TestEnv{..} = do
 testQM :: TestEnv -> Assertion
 testQM TestEnv{..} = do
     -- ? -> Does the string exist as a top-level key within the JSON value?
-    positiveQuery "SELECT ?::jsonb ?? ?" (testObj, "foo")
-    negativeQuery "SELECT ?::jsonb ?? ?" (testObj, "baz")
-    negativeQuery "SELECT ?::jsonb ?? ?" (toJSON [1,2,3,4,5], "1")
+    positiveQuery "SELECT ?::jsonb ?? ?" (testObj, "foo" :: Text)
+    negativeQuery "SELECT ?::jsonb ?? ?" (testObj, "baz" :: Text)
+    negativeQuery "SELECT ?::jsonb ?? ?" (toJSON numArray, "1" :: Text)
     -- ?| -> Do any of these array strings exist as top-level keys?
-    positiveQuery "SELECT ?::jsonb ??| ?" (testObj, ["nope","bar","6"])
-    negativeQuery "SELECT ?::jsonb ??| ?" (testObj, ["nope","6"])
-    negativeQuery "SELECT ?::jsonb ??| ?" (toJSON [1,2,3,4,5], ["1","2","6"])
+    positiveQuery "SELECT ?::jsonb ??| ?" (testObj, ["nope","bar","6"] :: [Text])
+    negativeQuery "SELECT ?::jsonb ??| ?" (testObj, ["nope","6"] :: [Text])
+    negativeQuery "SELECT ?::jsonb ??| ?" (toJSON numArray, ["1","2","6"] :: [Text])
     -- ?& -> Do all of these array strings exist as top-level keys?
-    positiveQuery "SELECT ?::jsonb ??& ?" (testObj, ["foo","bar","quux"])
-    negativeQuery "SELECT ?::jsonb ??& ?" (testObj, ["foo","bar"])
-    negativeQuery "SELECT ?::jsonb ??& ?" (toJSON [1,2,3,4,5], ["1","2","3","4","5"])
+    positiveQuery "SELECT ?::jsonb ??& ?" (testObj, ["foo","bar","quux"] :: [Text])
+    negativeQuery "SELECT ?::jsonb ??& ?" (testObj, ["foo","bar"] :: [Text])
+    negativeQuery "SELECT ?::jsonb ??& ?" (toJSON numArray, ["1","2","3","4","5"] :: [Text])
   where positiveQuery = boolQuery True
         negativeQuery = boolQuery False
+        numArray :: [Int]
+        numArray = [1,2,3,4,5]
         boolQuery b t x = do
             a <- query conn t x
-            [b] @?= a
-        testObj = toJSON (Map.fromList [("foo",toJSON 1)
-                                       ,("bar",toJSON "baz")
-                                       ,("quux",toJSON [1,2,3,4,5])] :: Map Text Value
+            [Only b] @?= a
+        testObj = toJSON (Map.fromList [("foo",toJSON (1 :: Int))
+                                       ,("bar",String "baz")
+                                       ,("quux",toJSON [1 :: Int,2,3,4,5])] :: Map Text Value
                          )
 
 testSavepoint :: TestEnv -> Assertion


### PR DESCRIPTION
This change makes it possible to use literal question marks in queries to PostgreSQL. This is needed to be able to use the new JSON operators. https://www.postgresql.org/docs/9.5/static/functions-json.html

This change can't break anything, since:

* Anyone using double question marks would get an error from `postgresql-simple` if not supplied the adequate amount of accompanying `Action`s (e.g. people trying the new JSON operators); or

* If supplied the adequate amount of accompanying `Action`s, PostgreSQL would throw a fit because you'd supply two values directly next to each other, which doesn't make sense.