### PR TITLE
Add some lower-bounds

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -69,12 +69,15 @@ Library
     postgresql-libpq >= 0.9 && < 0.10,
     template-haskell,
     text >= 0.11.1,
-    time,
+    time >= 1.1.4,
     transformers,
     uuid-types >= 1.0.0,
     scientific,
-    semigroups,
     vector
+
+  if !impl(ghc >= 8.0)
+    Build-depends:
+      semigroups >=0.18.2
 
   if !impl(ghc >= 7.6)
     Build-depends:


### PR DESCRIPTION
- semigroups is only needed with older GHC, but then we need a recent one,
  to have Semigroup Builder instance
- time >= 1.1.4, because of fromGregorianValid