### PR TITLE
Add 'Unpacked' Fields and Rows

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromRow.hs
+++ b/src/Database/PostgreSQL/Simple/FromRow.hs
@@ -88,6 +88,10 @@ getTypeInfoByCol Row{..} col =
     Conversion $ \conn -> do
       oid <- PQ.ftype rowresult col
       Ok <$> getTypeInfo conn oid
+getTypeInfoByCol UnpackedRow{..} col = typeInfo $ fst f
+  where PQ.Col c = col
+        f = unpackedRowValues !! fromIntegral c
+
 
 getTypenameByCol :: Row -> PQ.Column -> Conversion ByteString
 getTypenameByCol row col = typname <$> getTypeInfoByCol row col
@@ -95,27 +99,32 @@ getTypenameByCol row col = typname <$> getTypeInfoByCol row col
 fieldWith :: FieldParser a -> RowParser a
 fieldWith fieldP = RP $ do
     let unCol (PQ.Col x) = fromIntegral x :: Int
-    r@Row{..} <- ask
-    column <- lift get
-    lift (put (column + 1))
-    let ncols = nfields rowresult
-    if (column >= ncols)
-    then lift $ lift $ do
-        vals <- mapM (getTypenameByCol r) [0..ncols-1]
-        let err = ConversionFailed
-                (show (unCol ncols) ++ " values: " ++ show (map ellipsis vals))
-                Nothing
-                ""
-                ("at least " ++ show (unCol column + 1)
-                  ++ " slots in target type")
-                "mismatch between number of columns to \
-                \convert and number in target type"
-        conversionError err
-    else do
-      let !result = rowresult
-          !typeOid = unsafeDupablePerformIO (PQ.ftype result column)
-          !field = Field{..}
-      lift (lift (fieldP field (getvalue result row column)))
+    ask >>= \arst -> case arst of
+      UnpackedRow{..} -> do
+        column <- lift get
+        lift (put (column + 1))
+        lift $ lift $ uncurry fieldP $ unpackedRowValues !! unCol column
+      r@Row{..} -> do
+        column <- lift get
+        lift (put (column + 1))
+        let ncols = nfields rowresult
+        if (column >= ncols)
+        then lift $ lift $ do
+            vals <- mapM (getTypenameByCol r) [0..ncols-1]
+            let err = ConversionFailed
+                    (show (unCol ncols) ++ " values: " ++ show (map ellipsis vals))
+                    Nothing
+                    ""
+                    ("at least " ++ show (unCol column + 1)
+                      ++ " slots in target type")
+                    "mismatch between number of columns to \
+                    \convert and number in target type"
+            conversionError err
+        else do
+          let !result = rowresult
+              !fieldTypeOid = unsafeDupablePerformIO (PQ.ftype result column)
+              !field = Field{..}
+          lift (lift (fieldP field (getvalue result row column)))
 
 field :: FromField a => RowParser a
 field = fieldWith fromField

--- a/src/Database/PostgreSQL/Simple/FromRow.hs
+++ b/src/Database/PostgreSQL/Simple/FromRow.hs
@@ -99,12 +99,12 @@ getTypenameByCol row col = typname <$> getTypeInfoByCol row col
 fieldWith :: FieldParser a -> RowParser a
 fieldWith fieldP = RP $ do
     let unCol (PQ.Col x) = fromIntegral x :: Int
-    ask >>= \arst -> case arst of
+    ask >>= \r -> case r of
       UnpackedRow{..} -> do
         column <- lift get
         lift (put (column + 1))
         lift $ lift $ uncurry fieldP $ unpackedRowValues !! unCol column
-      r@Row{..} -> do
+      Row{..} -> do
         column <- lift get
         lift (put (column + 1))
         let ncols = nfields rowresult

--- a/src/Database/PostgreSQL/Simple/Range.hs
+++ b/src/Database/PostgreSQL/Simple/Range.hs
@@ -49,6 +49,7 @@ import           Data.Word                            (Word, Word16, Word32,
 
 import           Database.PostgreSQL.Simple.Compat    (scientificBuilder, (<>), toByteString)
 import           Database.PostgreSQL.Simple.FromField
+import           Database.PostgreSQL.Simple.Internal (setTypeOid)
 import           Database.PostgreSQL.Simple.Time
                    hiding (PosInfinity, NegInfinity)
 -- import qualified Database.PostgreSQL.Simple.Time as Time
@@ -197,7 +198,7 @@ fromFieldRange fromField' f mdat = do
     info <- typeInfo f
     case info of
       Range{} ->
-        let f' = f { typeOid = typoid (rngsubtype info) }
+        let f' = setTypeOid f $ typoid (rngsubtype info)
         in case mdat of
           Nothing -> returnError UnexpectedNull f ""
           Just "empty" -> pure $ empty


### PR DESCRIPTION
Unpacked is probably a bad way of putting it (nothing to do with the pragma...)

This is for using the FromRow/FromField instances for data coming from outside of libpq - in particular, a replication connection. It allows us to build the `Field` and `Row` without involving libpq.