### PR TITLE
Fix file name in extra-source-files

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -16,7 +16,7 @@ Cabal-version:       >= 1.9.2
 
 extra-source-files:
      CONTRIBUTORS
-     CHANGELOG.md
+     CHANGES.md
 
 Library
   hs-source-dirs: src


### PR DESCRIPTION
This removes the warning:

```
Warning: File listed in postgresql-simple.cabal file does not exist: CHANGELOG.md
```